### PR TITLE
Cloudconfig fixes

### DIFF
--- a/cache/usr/share/oem/cloud-config.yml
+++ b/cache/usr/share/oem/cloud-config.yml
@@ -1,0 +1,62 @@
+#cloud-config
+coreos:
+  units:
+  - name: systemd-modules-load.service
+    command: restart
+
+  - name: run-installer-script.service
+    command: start
+
+    content: |
+      [Unit]
+      Description=Wait for network connectivity and run installer script
+      Wants=network.target
+      After=network.target
+
+      [Service]
+      Type=oneshot
+      ExecStartPre=/bin/sh -c "while [[ -z $(curl -s $(cat /proc/cmdline | tr ' ' '\n' | awk -F= 'match($1, /mayu/) {print $2}')) ]] ; do sleep 1 ; done"
+      ExecStart=/tmp/maybe-install-coreos.sh
+
+      [Install]
+      WantedBy=multi-user.target
+  - name: systemd-modules-load.service
+    command: restart
+
+write_files:
+- path: /etc/modprobe.d/bonding.conf
+  permissions: 0644
+  owner: root
+  content: options bonding miimon=100 mode=4 lacp_rate=1
+- path: /etc/modules-load.d/ipmi.conf
+  permissions: 0644
+  owner: root
+  content: ipmi_devintf
+- path: /etc/modules-load.d/bonding.conf
+  permissions: 0644
+  owner: root
+  content: bonding
+- path: /tmp/maybe-install-coreos.sh
+  permissions: 0755
+  owner: root
+  content: |
+    #!/bin/bash
+
+    serial=$(cat /sys/devices/virtual/dmi/id/{product,chassis,board}_serial | tr  ' ' '-' | sed '/^\s*$/d' | head -1)
+    SCRIPT_URL=$(cat /proc/cmdline | tr ' ' '\n' | awk -F= 'match($1, /next-script/) {print $2}' | sed "s/__SERIAL__/$serial/")
+
+    wget -O /tmp/first_stage_script.sh $SCRIPT_URL
+    chmod +x /tmp/first_stage_script.sh
+    exec /tmp/first_stage_script.sh
+- path: /tmp/gs-installer-progress.sh
+  permissions: 0755
+  owner: root
+  content: |
+    #!/bin/sh
+    journalctl -fu run-installer-script.service
+- path: /etc/motd
+  permissions: 0644
+  owner: root
+  content: |
+    CoreOS is installing...
+    You can look at installation progresses running `/tmp/gs-installer-progress.sh`

--- a/config.go
+++ b/config.go
@@ -38,23 +38,23 @@ func loadConfig(filePath string) (configuration, error) {
 }
 
 type configuration struct {
-	filesystem         fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
-	FirstStageScript   string        `yaml:"first_stage_script"`
-	LastStageCC        string        `yaml:"last_stage_cloudconfig"`
-	TemplateSnippets   string        `yaml:"template_snippets"`
-	DNSmasqTmpl        string        `yaml:"dnsmasq_template"`
-	TFTPRoot           string
-	IPxe               string
-	HTTPBindAddr       string `yaml:"http_bind_addr"`
-	HTTPPort           int    `yaml:"http_port"`
-	NoSecure           bool   `yaml:"no_secure"`
-	HTTPSCertFile      string `yaml:"https_cert_file"`
-	HTTPSKeyFile       string `yaml:"https_key_file"`
-	Dnsmasq            string
-	ImagesCacheDir     string                 `yaml:"images_cache_dir"`
-	StaticHTMLPath     string                 `yaml:"static_html_path"`
-	YochuVersion string                 `yaml:"yochu_version"`
-	TemplatesEnv       map[string]interface{} `yaml:"templates_env"`
+	filesystem       fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
+	FirstStageScript string        `yaml:"first_stage_script"`
+	LastStageCC      string        `yaml:"last_stage_cloudconfig"`
+	TemplateSnippets string        `yaml:"template_snippets"`
+	DNSmasqTmpl      string        `yaml:"dnsmasq_template"`
+	TFTPRoot         string
+	IPxe             string
+	HTTPBindAddr     string `yaml:"http_bind_addr"`
+	HTTPPort         int    `yaml:"http_port"`
+	NoSecure         bool   `yaml:"no_secure"`
+	HTTPSCertFile    string `yaml:"https_cert_file"`
+	HTTPSKeyFile     string `yaml:"https_key_file"`
+	Dnsmasq          string
+	ImagesCacheDir   string                 `yaml:"images_cache_dir"`
+	StaticHTMLPath   string                 `yaml:"static_html_path"`
+	YochuVersion     string                 `yaml:"yochu_version"`
+	TemplatesEnv     map[string]interface{} `yaml:"templates_env"`
 
 	Profiles []profile
 

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -28,7 +28,7 @@ coreos:
       [Install]
       WantedBy=multi-user.target
 
-  {{ if .YochuVersion}}
+  {{if index .TemplatesEnv "yochu_version"}}
   - name: yochu.service
     command: start
     enable: true
@@ -49,7 +49,7 @@ coreos:
       ExecStartPre=/usr/bin/chmod +x /home/core/bin/mayuctl
       ExecStart=/home/core/bin/yochu setup -v -d --start-daemons=false --subnet="{{index .TemplatesEnv "yochu_localsubnet"}}" --gateway="{{index .TemplatesEnv "yochu_gateway"}}" --private-registry={{index .TemplatesEnv "yochu_private_registry"}} --http-endpoint={{index .TemplatesEnv "yochu_http_endpoint"}} --fleet-version=${FLEET_VERSION} --etcd-version=${ETCD_VERSION} --docker-version=${DOCKER_VERSION}
       ExecStartPost=/bin/sh -c 'sleep 5'
-      ExecStartPost=/home/core/bin/mayuctl boot-complete --host={{.MayuHost}} --port={{.MayuPort}} {{if .NoSecure}}--no-secure{{end}} --update-versions
+      ExecStartPost=/home/core/bin/mayuctl boot-complete --host={{.MayuHost}} --port={{.MayuPort}} {{if .NoSecure}}--no-secure {{end}}--update-versions
       RemainAfterExit=yes
 
       [Install]
@@ -86,9 +86,9 @@ write_files:
   permissions: 0644
   owner: root
   content: |
-    {{ range $server := .ClusterNetwork.DNS }}nameserver {{ $server }}
-    {{ end }}
-{{ if index .TemplatesEnv "yochu_version"}}
+    {{range $server := .ClusterNetwork.DNS }}nameserver {{ $server }}
+    {{end}}
+{{if index .TemplatesEnv "yochu_version"}}
 - path: /etc/yochu-env
   permissions: 0644
   owner: root
@@ -97,8 +97,8 @@ write_files:
     DOCKER_VERSION={{index .TemplatesEnv "docker_version"}}
     ETCD_VERSION={{index .TemplatesEnv "etcd_version"}}
     FLEET_VERSION={{index .TemplatesEnv "fleet_version"}}
-{{ end }}
+{{end}}
 
 ssh_authorized_keys:
-{{ range $index, $pubkey := (index .TemplatesEnv "ssh_authorized_keys")}}- {{ $pubkey }}
+{{range $index, $pubkey := (index .TemplatesEnv "ssh_authorized_keys")}}- {{ $pubkey }}
 {{end}}


### PR DESCRIPTION
The first stage cloud-config was compiled into the image (this is done in the `cache/coreos_production_pxe_image.cpio.gz` make target) and I forgot to add it to the repo.

Also the Yochu version check in the last stage cloud-config still wasn't correct. 

I was able to spin up a cluster with this fixes.