### PR TITLE
lock dns updates

### DIFF
--- a/pxemanager.go
+++ b/pxemanager.go
@@ -101,6 +101,9 @@ func (mgr *pxeManagerT) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (mgr *pxeManagerT) updateDNSmasqs() error {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
 	conf.Network.StaticHosts = []hostmgr.IPMac{}
 	conf.Network.IgnoredHosts = []string{}
 


### PR DESCRIPTION
Make sure that while multiple servers are installing dns is updated atomically.

Stumbled upon this during a test where Mayu reported a nil pointer exception within this function.