### PR TITLE
Docs cleanup iteration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Documentation
+# Mayu Documentation
 
 Here we provide more detailed documentation about Mayu.
 
-### Table Of Contents
+## Table Of Contents
 
 - [Mayu Configuration](configuration.md)
 - [Flags of the Mayu binary](flags.md)

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -1,16 +1,17 @@
 # Compiling Mayu
 
-In order to compile `mayu` you need to have `make` and [Docker](https://www.docker.com/) installed.
+In order to compile Mayu you need to have `make` and [Docker](https://www.docker.com/) installed.
 
 To compile all binaries of the projects running a simple `make` is sufficient.
 
 ## Updating vendors
 
-To update the vendored libraries used by `mayu`'s binaries you need to have
+To update the vendored libraries used by Mayu's binaries you need to have
 `make` and [glide](https://github.com/Masterminds/glide) installed.
 
 Updating the vendored libraries is done by running the following `make` targets:
-```
-make vendor-clean
-make vendor-update
+
+```nohighlight
+$ make vendor-clean
+$ make vendor-update
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,20 +7,20 @@ setup does not provide or rely on TLS for whatever reasons, you can set
 `mayuctl` is `--no-secure`. Check [mayuctl](mayuctl.md) for more
 information about the client.
 
-### File Tree
+## File Tree
 
-```
+```nohighlight
 .
-|-- mayu                            - the mayu executable
+|-- mayu                              - the mayu executable
 |-- config.yaml.dist                  - mayu configuration file template
 |-- images                            - directory containing the boot and installation images
-|   |-- ...
+|   `-- ...
 |-- static_html
 |   `-- infopusher                    - small node info pusher used during the installation process
 |-- templates
 |   |-- dnsmasq_template.conf         - template file used to generate the dnsmasq configuration
 |   |-- first_stage_script.sh         - template used to generate the installation script
-|   `-- last_stage_cloudconfig.yaml   - template used to generate the final cloud-config
+|   |-- last_stage_cloudconfig.yaml   - template used to generate the final cloud-config
 |-- template_snippets                 - directory containing some template snippets used by the final cloud-config
 |   |-- net_bond.yaml
 |   `-- net_singlenic.yaml
@@ -32,9 +32,8 @@ For a new environment to be configured, there are three main files that might
 have to be adapted: `config.yaml`, `last_stage_cloudconfig.yaml` and one of the
 network snippets `net_bond.yaml` or `net_singlenic.yaml`.
 
----
 
-### /etc/mayu/config.yaml
+## `/etc/mayu/config.yaml`
 
 The very first thing to do is to copy `config.yaml.dist` to
 `/etc/mayu/config.yaml` and modify it regarding your needs. The initial
@@ -42,7 +41,7 @@ section configures the paths to the templates, some binaries (ipxe and dnsmasq)
 and some directories. The default settings match the distributed mayu file
 tree.
 
-```
+```yaml
 tftproot: ./tftproot
 static_html_path: ./static_html
 ipxe: undionly.kpxe
@@ -55,24 +54,22 @@ images_cache_dir: ./images
 http_port: 4080
 ```
 
----
-
-###### Certificates
+### Certificates
 
 Communication between `mayu` and `mayuctl` by default is TLS encrypted. For
 that you need to provide certificates as follows. To disable this security
 feature you can set `no_secure` to `true`. Then no certificate needs to be
 provided.
 
-```
+```yaml
 no_secure: false
 https_cert_file: "./cert.pem"
 https_key_file: "./key.pem"
 ```
 
-###### Network
+### Network
 
-```
+```yaml
 network:
   pxe: true
   interface: bond0
@@ -94,11 +91,9 @@ installation. The `ip_range` is a range of addresses that will be statically
 assigned to the cluster nodes. The `network_model` specifies which network
 template snippet will be used.
 
----
+### Profiles
 
-###### Profiles
-
-```
+```yaml
 profiles:
   - name: core
     quantity: 3
@@ -120,11 +115,10 @@ means we have 3 nodes with the profile core), mayu will assign the profile
 "default" to the remaining nodes. Thus, profiles with a `quantity` set are of
 higher priority than the default profile.
 
----
 
-###### Template Variables For Cloudconfig
+### Template Variables For Cloudconfig
 
-```
+```yaml
 templates_env:
   ssh_authorized_keys:
     - "ssh-rsa ..."
@@ -137,7 +131,7 @@ templates_env:
 These variables are used by the templates (most of them are directly injected
 into the final cloudconfig file).
 
-### last_stage_cloudconfig.yaml
+## `last_stage_cloudconfig.yaml`
 
 This template is a vanilla
 [cloud-config](https://coreos.com/os/docs/latest/cloud-config.html) file with a
@@ -145,13 +139,13 @@ few additions to automatically deploy the Giant Swarm yochu, setup the
 fleet metadata, define the etcd discovery url, update the `ssh_authorized_keys`
 for the user `core` and configure the network.
 
-### template_snippets/net_singlenic.yaml
+## `template_snippets/net_singlenic.yaml`
 
 In the near future, the existence of multiple network template snippets will be
 changed, so we'll focus on the singlenic template (used by the default
 configuration) for now.
 
-```
+```yaml
 {{define "net_singlenic"}}
   - name: systemd-networkd.service
     command: stop
@@ -195,4 +189,3 @@ defines the
 In this example it just disables DHCP and configures the `ConnectedNIC` with a
 static IP address. The `ConnectedNIC` is aquired during installation time by
 analyzing which interface is used to reach the default gateway.
-

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -1,9 +1,9 @@
-# Flags of the Mayu binary
+# Flags of the 'mayu' binary
 
 Mayu provides the following command line flags. When doing `mayu -h` you
 should see this.
 
-```
+```nohighlight
 Usage of mayu:
   -alsologtostderr
       log to standard error as well as files

--- a/docs/inside.md
+++ b/docs/inside.md
@@ -4,7 +4,7 @@ Here we looking inside a deployed cluster. New nodes can be added to the
 cluster at any time and the same bootstrap procedure will be applied. In this
 example, we created a 4 node cluster:
 
-```
+```nohighlight
 $ cd cluster
 $ egrep -r 'Host|InternalAddr' */conf.json
 004b27ed-692e-b32e-1f68-d89aff66c71b/conf.json:  "InternalAddr": "10.0.3.31",
@@ -17,7 +17,7 @@ aa1f18e1-f14f-2dd9-4fa0-dae7317c712c/conf.json:  "InternalAddr": "10.0.3.34",
 aa1f18e1-f14f-2dd9-4fa0-dae7317c712c/conf.json:  "Hostname": "0000b1895b74c624",
 ```
 
-```
+```nohighlight
 $ ssh core@10.0.3.31 fleetctl list-machines -l
 Warning: Permanently added '10.0.3.31' (ED25519) to the list of known hosts.
 MACHINE         IP    METADATA
@@ -38,13 +38,10 @@ How It Works? Let's start by analyzing the bootstrap process of a fresh node:
 Adding a fresh node to the cluster consists of three parts:
 
 * initial boot
-
 * system installation
-
 * final reboot to installed system
 
-
-###### Initial boot
+## Initial boot
 
 The fresh node is by definition empty and boots over ethernet by default. It
 sends a DHCP request for a `pxeclient`, which gets answered by the management
@@ -55,9 +52,7 @@ path. The node then requests the kernel image and subsequently the initial root
 directory over HTTP. With this the node can then boot into installation from
 the initial root directory.
 
----
-
-###### System Installation
+## System Installation
 
 The initial root directory contains a version of CoreOS that is modified to run
 one unit that in turn requests a first stage script and runs that. The script
@@ -68,9 +63,7 @@ cached on the management node. This image gets installed by default to
 `/dev/sda` configured through the above-mentioned `cloudconfig`. Finally the
 node announces itself as installed to the management node and reboots.
 
----
-
-###### Final Reboot To Installed System
+## Final Reboot To Installed System
 
 On the final reboot (as well as each next reboot, as long as nothing in the
 mayu configuration gets changed) the node will again try to boot over

--- a/docs/mayuctl.md
+++ b/docs/mayuctl.md
@@ -1,16 +1,16 @@
-# mayuctl
+# `mayuctl` - The Mayu Client
 
-`mayuctl` is a client implementation to interact with mayu. By default TLS
+`mayuctl` is a client implementation to interact with `mayu`. By default TLS
 is enabled. If your setup does not provide or rely on TLS for whatever reasons,
 you can use the `--no-secure` flag to disable TLS and only communicate over
-HTTP. The corresponding option for `mayu` can be set in the `config.yaml`.
+HTTP. The corresponding option for `mayuctl` can be set in the `config.yaml`.
 There you just need to set `no_secure` to `true`.
 
-### Help Usage
+## Help Usage
 
 Lets have a look at the help usage.
 
-```
+```nohighlight
 Manage a mayu cluster
 
 Usage:
@@ -32,23 +32,23 @@ Flags:
 Use "mayuctl [command] --help" for more information about a command.
 ```
 
-### List Machines
+## List Machines
 
 Checking what machines are within a cluster can be done using the `list`
 command. You should see output like this.
 
-```
+```nohighlight
 $ mayuctl list
 IP           Serial                                Profile  State      Last Boot
 172.17.8.31  004b27ed-692e-b32e-1f68-d89aff66c71b  core     "running"  2016-01-15 13:42:33.344687863 +0000 UTC
 ```
 
-### Check Machine Status
+## Check Machine Status
 
 To inspect a machine's status there is the `status` command. The output should
 be something like this.
 
-```
+```nohighlight
 $ mayuctl status 004b27ed-692e-b32e-1f68-d89aff66c71b
 Serial:              004b27ed-692e-b32e-1f68-d89aff66c71b
 IP:                  172.17.8.31

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,15 +1,15 @@
 # Release A New Mayu Version
 
-In general releases can be found here: https://github.com/giantswarm/mayu/releases
+Releases can be found here: https://github.com/giantswarm/mayu/releases
 
-To prepare a release make sure all important changes are in master branch. Once
+To prepare a release, make sure all important changes are in the `master` branch. Once
 a git tag is created and pushed, checkout the git tag locally and create the
 distribution package.
 
-```
+```nohighlight
 make bin-dist
 ```
 
-This will create a `*.tar.gz` tarball you can upload to the github release
-page. Because the tarball contains a lot of stuff (< 400 MB) the upload will
+This will create a `tar.gz` tarball you can upload to the GitHub release
+page. Since the tarball contains a lot of stuff (< 400 MB), the upload will
 take a while. Make sure you provide a sufficient release title and desciption.

--- a/docs/running.md
+++ b/docs/running.md
@@ -2,14 +2,14 @@
 
 Once Mayu is properly configured, it can be started:
 
-```
+```nohighlight
 make bin-dist
 ./mayu -cluster-directory cluster -v=12 -no-git
 ```
 
 You can also run it within a Docker container:
 
-```
+```nohighlight
 docker run --rm -it \
   --cap-add=NET_ADMIN \
   --net=host \
@@ -18,13 +18,13 @@ docker run --rm -it \
   giantswarm/mayu \
   -v=12 -no-git
 ```
-  
+
 Or use the `mayu.service` unit file included in the `giantswarm/mayu` repository.
 
 Mayu is now ready to bootstrap a new cluster. Mayu uses the
 `cluster-directory` to save the cluster state:
 
-```
+```nohighlight
 $ tree cluster
 cluster
 |-- 004b27ed-692e-b32e-1f68-d89aff66c71b
@@ -41,7 +41,7 @@ cluster
 Each cluster node has its own directory (identified by the serial number)
 containing a JSON file with data about the node:
 
-```
+```json
 {
   "Enabled": true,
   "Serial": "004b27ed-692e-b32e-1f68-d89aff66c71b",
@@ -65,7 +65,7 @@ The cluster directory itself contains a `cluster.json` file with persistent
 data about the cluster. If this file doesn't exist, it is initialized by
 mayu.
 
-```
+```json
 {
   "GitStore": true,
   "Config": {
@@ -77,7 +77,7 @@ mayu.
 By default, mayu treats the cluster directory as a git repository, commiting
 every change:
 
-```
+```nohighlight
 $ git log --format="%ai => %s"
 2015-10-08 19:14:37 +0200 => aa1f18e1-f14f-2dd9-4fa0-dae7317c712c: updated state to running
 2015-10-08 19:14:36 +0200 => 004b27ed-692e-b32e-1f68-d89aff66c71b: updated state to running

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,11 +31,11 @@ See  http://security.stackexchange.com/questions/64915/what-are-the-biggest-secu
 > - Computer makes a DHCP request
 > - DHCP server responds with address and PXE parameters
 > - Computer downloads boot image using TFTP over UDP
-> 
+>
 > The obvious attacks are a rogue DHCP server responding with bad data (and thus
 > hijacking the boot process) and a rogue TFTP server blindly injecting forged
 > packets (hijacking or corrupting the boot image).
-> 
+>
 > UEFI secure boot can be used to prevent hijacking, but a rogue DHCP or TFTP
 > server can still prevent booting by ensuring the computer receives a corrupted
 > boot image.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,7 +4,7 @@ In your `/etc/mayu/config.yaml` you can define template environment variables
 that are dynamically usable in `templates/last_stage_cloudconfig.yaml` when
 doing tne following.
 
-```
+```yaml
 templates_env:
   ssh_authorized_keys:
     - "pub key one"
@@ -19,7 +19,7 @@ looks like the following. Because the last stage template is effectively a
 cloud config, that way you can configure it dynamically to your own needs. As
 here seen configuring ssh keys.
 
-```
+```nohighlight
 ssh_authorized_keys:
 {{ range $index, $pubkey := (index .TemplatesEnv "ssh_authorized_keys")}}- {{ $pubkey }}
 {{end}}


### PR DESCRIPTION
- renamed `bootxectl.md` to `mayuctl.md`
- Wrote Mayu when the entire software is referenced. Wrote `mayu`
when the specific binary is meant.
- Set syntax highlighting helpers (“nohighlight” for all shell, mixed
and plain text output)
- Applied strict headline hierarchy
- Removed — (horizontal lines), since headlines should be enough to
structure the content
- Set file names in headlines in backticks (literals)
- Removed superfluous empty lines
- very few language modifications

RFR @puja108 