### PR TITLE
Etcd, fleet, docker independent from releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,9 @@ ifndef GOARCH
   GOARCH := $(shell go env GOARCH)
 endif
 
-ETCD_VERSION := v2.2.5-gs-1
-FLEET_VERSION := v0.11.3-gs-2
-DOCKER_VERSION := 1.6.2
-YOCHU_VERSION := 0.18.0
-
 .PHONY: all clean bin-dist clean-bin-dist publish vendor-clean vendor-update
 
-all: .gobuild infopusher/infopusher helpers/infopusher $(BINARY_SERVER) $(BINARY_CTL) cache/yochu/$(YOCHU_VERSION) cache/fleet/$(FLEET_VERSION) cache/etcd/$(ETCD_VERSION) cache/docker/$(DOCKER_VERSION)
+all: .gobuild infopusher/infopusher helpers/infopusher $(BINARY_SERVER) $(BINARY_CTL)
 
 .gobuild:
 	mkdir -p $(PROJECT_PATH)
@@ -74,35 +69,11 @@ $(BINARY_CTL): $(SOURCE) VERSION .gobuild
       golang:1.5 \
 	    go build -a -ldflags "-X main.projectVersion=$(VERSION) -X main.projectBuild=$(COMMIT)" -o $(BINARY_CTL) github.com/$(ORGANIZATION)/$(PROJECT)/mayuctl
 
-distclean: clean clean-cache clean-bin-dist
+distclean: clean clean-bin-dist
 
 clean:
 	rm -rf .gobuild bin helpers/infopusher
 	cd infopusher ; make clean
-
-clean-cache:
-	rm -rf cache/yochu
-	rm -rf cache/etcd
-	rm -rf cache/fleet
-	rm -rf cache/docker
-
-cache/yochu/$(YOCHU_VERSION):
-	mkdir -p cache/yochu/${YOCHU_VERSION}
-	wget -O cache/yochu/${YOCHU_VERSION}/yochu https://downloads.giantswarm.io/yochu/${YOCHU_VERSION}/yochu
-
-cache/etcd/$(ETCD_VERSION):
-	mkdir -p cache/etcd/${ETCD_VERSION}
-	wget -O cache/etcd/${ETCD_VERSION}/etcd https://downloads.giantswarm.io/etcd/${ETCD_VERSION}/etcd
-	wget -O cache/etcd/${ETCD_VERSION}/etcdctl https://downloads.giantswarm.io/etcd/${ETCD_VERSION}/etcdctl
-
-cache/fleet/$(FLEET_VERSION):
-	mkdir -p cache/fleet/${FLEET_VERSION}
-	wget -O cache/fleet/${FLEET_VERSION}/fleetd https://downloads.giantswarm.io/fleet/${FLEET_VERSION}/fleetd
-	wget -O cache/fleet/${FLEET_VERSION}/fleetctl https://downloads.giantswarm.io/fleet/${FLEET_VERSION}/fleetctl
-
-cache/docker/$(DOCKER_VERSION):
-	mkdir -p cache/docker/${DOCKER_VERSION}
-	wget -O cache/docker/${DOCKER_VERSION}/docker https://downloads.giantswarm.io/docker/${DOCKER_VERSION}/docker
 
 clean-bin-dist:
 	rm -fr bin-dist
@@ -116,10 +87,6 @@ bin-dist: all
 	cp helpers/undionly.kpxe bin-dist/tftproot
 	cp infopusher/infopusher bin-dist/static_html
 	cp $(BINARY_CTL) bin-dist/static_html
-	cp -R cache/yochu bin-dist/static_html
-	cp -R cache/etcd bin-dist/static_html
-	cp -R cache/fleet bin-dist/static_html
-	cp -R cache/docker bin-dist/static_html
 	cp -f $(BINARY_SERVER) bin-dist
 	cp -f $(BINARY_CTL) bin-dist
 	cp config.yaml.dist bin-dist
@@ -128,6 +95,7 @@ bin-dist: all
 	cp -a templates/* bin-dist/templates
 	cp -a template_snippets/* bin-dist/template_snippets
 	cp scripts/fetch-coreos-image bin-dist/fetch-coreos-image
+	cp scripts/fetch-mayu-assets bin-dist/fetch-mayu-assets
 	cd bin-dist && rm -f $(PROJECT).*.tar.gz && tar czf $(PROJECT).$(VERSION).tar.gz *
 
 vendor-clean:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Fetch a CoreOS image that you want to provision on your machines:
 ./fetch-coreos-image 835.13.0
 ```
 
+Fetch docker, etcd, fleet versions you would like to provision on your CoreOS machines via Yochu:
+
+```
+./fetch-mayu-assets
+```
+
 ### Run Mayu from source
 
 start mayu:
@@ -74,6 +80,7 @@ docker run --rm -it \
   --name=mayu \
   -v /var/lib/mayu:/var/lib/mayu \
   -v /usr/lib/mayu/images:/usr/lib/mayu/images \
+  -v /usr/lib/mayu/assets:/usr/lib/mayu/assets \
   giantswarm/mayu \
   -v=12 -no-git
 ```

--- a/config.go
+++ b/config.go
@@ -53,6 +53,7 @@ type configuration struct {
 	Dnsmasq          string
 	ImagesCacheDir   string                 `yaml:"images_cache_dir"`
 	StaticHTMLPath   string                 `yaml:"static_html_path"`
+	AssetsPath       string                 `yaml:"assets_path"`
 	YochuVersion     string                 `yaml:"yochu_version"`
 	TemplatesEnv     map[string]interface{} `yaml:"templates_env"`
 

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,4 +1,5 @@
 tftproot: ./tftproot
+assets_path: ./assets
 static_html_path: ./static_html
 ipxe: undionly.kpxe
 first_stage_script: ./templates/first_stage_script.sh

--- a/pxemanager.go
+++ b/pxemanager.go
@@ -73,8 +73,11 @@ func (mgr *pxeManagerT) startIPXEserver() error {
 	// add welcome handler for debugging
 	mgr.router.Path("/").HandlerFunc(mgr.welcomeHandler)
 
-	// serve static files like yochu, fleet, etc.
+	// serve static files like infopusher and mayuctl etc.
 	mgr.router.PathPrefix("/").Handler(http.FileServer(http.Dir(conf.StaticHTMLPath)))
+
+	// serve assets for yochu like etcd, fleet and docker
+	mgr.router.PathPrefix("/").Handler(http.FileServer(http.Dir(conf.AssetsPath)))
 
 	glogWrapper := logging.NewGlogWrapper(8)
 	loggedRouter := handlers.LoggingHandler(glogWrapper, mgr.router)

--- a/scripts/fetch-mayu-assets
+++ b/scripts/fetch-mayu-assets
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+ETCD_VERSION := v2.2.5-gs-1
+FLEET_VERSION := v0.11.3-gs-2
+DOCKER_VERSION := 1.6.2
+YOCHU_VERSION := 0.18.0
+
+mkdir -p ./assets
+
+if [ ! -d "./assets/yochu/${YOCHU_VERSION}" ]; then
+	mkdir -p ./assets/yochu/${YOCHU_VERSION}
+	wget -O ./assets/yochu/${YOCHU_VERSION}/yochu https://downloads.giantswarm.io/yochu/${YOCHU_VERSION}/yochu
+fi
+
+if [ ! -d "./assets/etcd/${ETCD_VERSION}" ]; then
+	mkdir -p ./assets/etcd/${ETCD_VERSION}
+	wget -O ./assets/etcd/${ETCD_VERSION}/etcd https://downloads.giantswarm.io/etcd/${ETCD_VERSION}/etcd
+	wget -O ./assets/etcd/${ETCD_VERSION}/etcdctl https://downloads.giantswarm.io/etcd/${ETCD_VERSION}/etcdctl
+fi
+
+if [ ! -d "./assets/fleet/${FLEET_VERSION}" ]; then
+	mkdir -p ./assets/fleet/${FLEET_VERSION}
+	wget -O ./assets/fleet/${FLEET_VERSION}/fleetd https://downloads.giantswarm.io/fleet/${FLEET_VERSION}/fleetd
+	wget -O ./assets/fleet/${FLEET_VERSION}/fleetctl https://downloads.giantswarm.io/fleet/${FLEET_VERSION}/fleetctl
+fi
+
+if [ ! -d "./assets/docker/${DOCKER_VERSION}" ]; then
+	mkdir -p ./assets/docker/${DOCKER_VERSION}
+	wget -O ./assets/docker/${DOCKER_VERSION}/docker https://downloads.giantswarm.io/docker/${DOCKER_VERSION}/docker
+fi


### PR DESCRIPTION
removed etcd, fleet, docker and yochu from release. you can fetch your own versions now independently from a release.

* smaller docker image
* multiple versions in parallel

Similar to #33 