### PR TITLE
change fields in mayuctl list and sort the output

### DIFF
--- a/mayuctl/list.go
+++ b/mayuctl/list.go
@@ -104,7 +104,7 @@ func init() {
 
 func listRun(cmd *cobra.Command, args []string) {
 	if listFlags.Fields == "" {
-		fmt.Printf("You have to define fields for the output. This can't be empty.\n\nUsage: %s\n", cmd.Usage())
+		fmt.Printf("Invalid fields parameter. Please choose valid fields: %s\n", strings.Join(hostToFieldKeys(listFields), ","))
 		os.Exit(1)
 	}
 

--- a/mayuctl/list.go
+++ b/mayuctl/list.go
@@ -2,44 +2,144 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"sort"
+	"strings"
 
 	"github.com/giantswarm/mayu/hostmgr"
 	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultListFields = "ip,serial,profile,ipmiaddr,providerid,metadata,coreos,state,lastboot"
+	timestampFormat   = "2006-01-02 15:04:05"
+)
+
+type ListFlags struct {
+	Fields   string
+	NoLegend bool
+}
+
+type hostToField func(host *hostmgr.Host) string
+
 var (
 	listCmd = &cobra.Command{
-		Use:   "list",
+		Use:   "list [--no-legend] [--fields]",
 		Short: "List machines.",
-		Long:  "List machines.",
-		Run:   listRun,
+		Long: `List the state of all machines in a Mayu datacenter.
+
+For easily parsable output, you can remove the column headers:
+	mayuctl list --no-legend
+
+Or, choose the columns to display:
+	mayuctl list --fields=ip,machineid,ipmiaddr`,
+		Run: listRun,
 	}
+
+	listFields = map[string]hostToField{
+		"ip": func(host *hostmgr.Host) string {
+			if host.InternalAddr == nil {
+				return "-"
+			}
+			return host.InternalAddr.String()
+		},
+		"serial": func(host *hostmgr.Host) string {
+			return host.Serial
+		},
+		"profile": func(host *hostmgr.Host) string {
+			if host.Profile == "" {
+				return "-"
+			}
+			return host.Profile
+		},
+		"ipmiaddr": func(host *hostmgr.Host) string {
+			if host.IPMIAddr == nil {
+				return "-"
+			}
+			return host.IPMIAddr.String()
+		},
+		"providerid": func(host *hostmgr.Host) string {
+			if host.ProviderId == "" {
+				return "-"
+			}
+			return host.ProviderId
+		},
+		"metadata": func(host *hostmgr.Host) string {
+			return host.FleetMetadata.String()
+		},
+		"coreos": func(host *hostmgr.Host) string {
+			return host.CoreOSVersion
+		},
+		"yochu": func(host *hostmgr.Host) string {
+			return host.YochuVersion
+		},
+		"fleet": func(host *hostmgr.Host) string {
+			return host.FleetVersion
+		},
+		"etcd": func(host *hostmgr.Host) string {
+			return host.EtcdVersion
+		},
+		"docker": func(host *hostmgr.Host) string {
+			return host.DockerVersion
+		},
+		"machineid": func(host *hostmgr.Host) string {
+			return host.MachineID
+		},
+		"state": func(host *hostmgr.Host) string {
+			return hostmgr.HostStateMap()[host.State]
+		},
+		"lastboot": func(host *hostmgr.Host) string {
+			return host.LastBoot.Format(timestampFormat)
+		},
+	}
+
+	listFlags = &ListFlags{}
 )
 
-const (
-	listHeader      = "IP | Serial | Profile | IPMI Address | ProviderId | Fleet | CoreOS | State | Last Boot"
-	listScheme      = "%s | %s | %s | %s | %s | %s | %s | %s | %s"
-	timestampFormat = "2006-01-02 15:04:05"
-)
+func init() {
+	listCmd.PersistentFlags().BoolVar(&listFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
+	listCmd.PersistentFlags().StringVar(&listFlags.Fields, "fields", defaultListFields, fmt.Sprintf("Columns to print for each Machine. Valid fields are %q", strings.Join(hostToFieldKeys(listFields), ",")))
+}
 
 func listRun(cmd *cobra.Command, args []string) {
+	if listFlags.Fields == "" {
+		fmt.Printf("You have to define fields for the output. This can't be empty.\n\nUsage: %s\n", cmd.Usage())
+		os.Exit(1)
+	}
+
+	cols := strings.Split(listFlags.Fields, ",")
+	for _, s := range cols {
+		if _, ok := listFields[s]; !ok {
+			fmt.Printf("Invalid field: %q.\n\nUsage: %s\n", s, cmd.Usage())
+			os.Exit(1)
+		}
+	}
+
 	hosts, err := mayu.List()
 	assert(err)
 
-	lines := []string{listHeader}
+	lines := []string{}
 	for _, host := range hosts {
-		lines = append(lines, fmt.Sprintf(listScheme,
-			host.InternalAddr,
-			host.Serial,
-			host.Profile,
-			host.IPMIAddr,
-			host.ProviderId,
-			host.FleetMetadata,
-			host.CoreOSVersion,
-			hostmgr.HostStateMap()[host.State],
-			host.LastBoot.Format(timestampFormat),
-		))
+		var f []string
+		for _, c := range cols {
+			f = append(f, listFields[c](&host))
+		}
+		lines = append(lines, strings.Join(f, "|"))
 	}
+	sort.Strings(lines)
+
+	if !listFlags.NoLegend {
+		lines = append([]string{strings.ToUpper(strings.Join(cols, "|"))}, lines...)
+	}
+
 	fmt.Println(columnize.SimpleFormat(lines))
+}
+
+func hostToFieldKeys(m map[string]hostToField) (keys []string) {
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return
 }


### PR DESCRIPTION
Added two new parameters:

Omit the legend of the output
```
mayuctl list --no-legend
```

Change the fields in the output
```
mayuctl list --fields=machined,profile,coreos,yochu
```

The output will be sorted (currently only comparing the full string of each line)