### PR TITLE
Masking locksmithd service

### DIFF
--- a/templates/examples/bonding.yaml
+++ b/templates/examples/bonding.yaml
@@ -6,6 +6,7 @@ coreos:
     command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: systemd-modules-load.service
     command: restart

--- a/templates/examples/bonding.yaml
+++ b/templates/examples/bonding.yaml
@@ -5,6 +5,8 @@ coreos:
   - name: update-engine.service
     command: stop
     mask: true
+  - name: locksmithd.service
+    mask: true
   - name: systemd-modules-load.service
     command: restart
 {{template "quobyte" .}}

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -7,6 +7,7 @@ coreos:
     command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
 {{template "quobyte" .}}
 {{if eq .ClusterNetwork.NetworkModel "bond"}}{{template "net_bond" .}}{{end}}

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -6,6 +6,8 @@ coreos:
     enable: false
     command: stop
     mask: true
+  - name: locksmithd.service
+    mask: true
 {{template "quobyte" .}}
 {{if eq .ClusterNetwork.NetworkModel "bond"}}{{template "net_bond" .}}{{end}}
 {{if eq .ClusterNetwork.NetworkModel "singlenic"}}{{template "net_singlenic" .}}{{end}}


### PR DESCRIPTION
Mask the service locksmithd to avoid weird behaviors and states.

```
-- Reboot --
Mar 04 09:35:54 00002c1a00dd1eda systemd[1]: Started Cluster reboot manager.
Mar 04 09:35:54 00002c1a00dd1eda systemd[1]: Starting Cluster reboot manager...
Mar 04 09:35:54 00002c1a00dd1eda locksmithd[692]: Cannot get update engine status: The name com.coreos.update1 was not provided by any .service files
Mar 04 09:35:54 00002c1a00dd1eda systemd[1]: locksmithd.service: main process exited, code=exited, status=1/FAILURE
Mar 04 09:35:54 00002c1a00dd1eda systemd[1]: Unit locksmithd.service entered failed state.
Mar 04 09:35:54 00002c1a00dd1eda systemd[1]: locksmithd.service failed.
Mar 04 09:35:55 00002c1a00dd1eda systemd[1]: locksmithd.service holdoff time over, scheduling restart.
Mar 04 09:35:55 00002c1a00dd1eda systemd[1]: locksmithd.service failed to schedule restart job: Unit locksmithd.service is masked.
Mar 04 09:35:55 00002c1a00dd1eda systemd[1]: Unit locksmithd.service entered failed state.
Mar 04 09:35:55 00002c1a00dd1eda systemd[1]: locksmithd.service failed.
Mar 04 09:36:46 00002c1a00dd1eda systemd[1]: Stopped locksmithd.service.
-- Reboot --
Mar 04 09:55:43 00002c1a00dd1eda systemd[1]: Started Cluster reboot manager.
Mar 04 09:55:43 00002c1a00dd1eda systemd[1]: Starting Cluster reboot manager...
Mar 04 09:55:43 00002c1a00dd1eda locksmithd[699]: Cannot get update engine status: The name com.coreos.update1 was not provided by any .service files
Mar 04 09:55:43 00002c1a00dd1eda systemd[1]: locksmithd.service: main process exited, code=exited, status=1/FAILURE
Mar 04 09:55:43 00002c1a00dd1eda systemd[1]: Unit locksmithd.service entered failed state.
Mar 04 09:55:43 00002c1a00dd1eda systemd[1]: locksmithd.service failed.
Mar 04 09:55:44 00002c1a00dd1eda systemd[1]: locksmithd.service holdoff time over, scheduling restart.
Mar 04 09:55:44 00002c1a00dd1eda systemd[1]: locksmithd.service failed to schedule restart job: Unit locksmithd.service is masked.
```