### PR TITLE
Add disable_engine property to specify fleet disable engine value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Mayu
 
 [![Build Status](https://api.travis-ci.org/giantswarm/mayu.svg)](https://travis-ci.org/giantswarm/mayu)
-[![](https://godoc.org/github.com/giantswarm/mayu?status.svg)](http://godoc.org/github.com/giantswarm/mayu) [![](https://img.shields.io/docker/pulls/giantswarm/mayu.svg)](http://hub.docker.com/giantswarm/mayu) [![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
+[![](https://godoc.org/github.com/giantswarm/mayu?status.svg)](http://godoc.org/github.com/giantswarm/mayu) [![](https://img.shields.io/docker/pulls/giantswarm/mayu.svg)](http://hub.docker.com/giantswarm/mayu)
+[![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/mayu)](https://goreportcard.com/report/github.com/giantswarm/mayu)
+[![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
 
 Mayu provides a set of mechanisms to bootstrap PXE-enabled bare metal nodes
 that must follow a specific configuration with CoreOS. It sets up fleet
-meta-data, and patched versions of fleet, etcd, and docker when using 
+meta-data, and patched versions of fleet, etcd, and docker when using
 [Yochu](https://github.com/giantswarm/yochu).
 
 ## Prerequisites

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -18,6 +18,7 @@ profiles:
     tags:
       - "role-core=true"
   - name: default
+    disable_engine: true
     tags:
       - "role-worker=true"
       - "stack-compute=true"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 Here we provide more detailed documentation about configuring Mayu. By
 default TLS is enabled when communicating with `mayu` over network. If your
 setup does not provide or rely on TLS for whatever reasons, you can set
-`--no-tls`. The corresponding flag for `mayuctl` is `--no-tls`. 
+`--no-tls`. The corresponding flag for `mayuctl` is `--no-tls`.
 Check [mayuctl](mayuctl.md) for more information about the client.
 
 ## File Tree
@@ -37,7 +37,7 @@ network snippets `net_bond.yaml` or `net_singlenic.yaml`.
 The very first thing to do is to copy `config.yaml.dist` to
 `/etc/mayu/config.yaml` and modify it regarding your needs. The initial
 section configures the network, profiles for the machines and the versions
-of the software that should be installed via Yochu. 
+of the software that should be installed via Yochu.
 
 ### Network
 
@@ -80,12 +80,13 @@ profiles:
 The final goal of a mayu-enabled deployment is a functional fleet cluster. To
 be able to assign different roles to the different nodes, mayu employs a
 mechanism of profile selection. Each profile has a `name`, a `quantity`
-(defines the number of cluster nodes that should have this profile) and a list
-of `tags` (the elements of this list will be directly mapped to fleet metadata
-tags). Once all the profiles' quantities are matched (in this example that
-means we have 3 nodes with the profile core), mayu will assign the profile
-"default" to the remaining nodes. Thus, profiles with a `quantity` set are of
-higher priority than the default profile.
+(defines the number of cluster nodes that should have this profile), a
+`disable_engine` (defines whether the cluster nodes can be elected as fleet
+leader) and a list of `tags` (the elements of this list will be directly mapped
+to fleet metadata tags). Once all the profiles' quantities are matched (in
+this example that means we have 3 nodes with the profile core), mayu will assign
+the profile "default" to the remaining nodes. Thus, profiles with a `quantity`
+set are of higher priority than the default profile.
 
 ### Template Variables For Cloudconfig
 

--- a/docs/mayuctl.md
+++ b/docs/mayuctl.md
@@ -42,7 +42,7 @@ IP           Serial                                Profile  State      Last Boot
 172.17.8.31  004b27ed-692e-b32e-1f68-d89aff66c71b  core     "running"  2016-01-15 13:42:33.344687863 +0000 UTC
 ```
 
-You can also change the fields that should be listed. 
+You can also change the fields that should be listed.
 
 ```nohighlight
 $ mayuctl list -fields=ip,yochu,etcd
@@ -68,6 +68,7 @@ Hostname:            00007e267361d01f
 MachineID:           00007e267361d01f233a3ed4900dcebb
 ConnectedNIC:        enp0s3
 Profile:             core
+DisableEngine:       false
 State:               "running"
 Metadata:            role-core=true
 CoreOS:              835.13.0

--- a/hostmgr/host.go
+++ b/hostmgr/host.go
@@ -15,24 +15,25 @@ const hostConfFile = "conf.json"
 
 // Host represents a node within the mayu cluster.
 type Host struct {
-	Id               int       `json:",omitempty"`
-	ProviderId       string    `json:",omitempty"`
-	Enabled          bool      `json:",omitempty"`
-	Name             string    `json:",omitempty"`
-	Serial           string    `json:",omitempty"`
-	MacAddresses     []string  `json:",omitempty"`
-	InternalAddr     net.IP    `json:",omitempty"`
-	BondInterfaces   []string  `json:",omitempty"`
-	Cabinet          uint      `json:",omitempty"`
-	MachineOnCabinet uint      `json:",omitempty"`
-	IPMIAddr         net.IP    `json:",omitempty"`
-	Hostname         string    `json:",omitempty"`
-	MachineID        string    `json:",omitempty"`
-	ConnectedNIC     string    `json:",omitempty`
-	FleetMetadata    FleetMeta `json:",omitempty"`
-	KeepDiskData     bool      `json:",omitempty"`
-	LastBoot         time.Time `json:",omitempty"`
-	Profile          string    `json:",omitempty"`
+	Id                 int       `json:",omitempty"`
+	ProviderId         string    `json:",omitempty"`
+	Enabled            bool      `json:",omitempty"`
+	Name               string    `json:",omitempty"`
+	Serial             string    `json:",omitempty"`
+	MacAddresses       []string  `json:",omitempty"`
+	InternalAddr       net.IP    `json:",omitempty"`
+	BondInterfaces     []string  `json:",omitempty"`
+	Cabinet            uint      `json:",omitempty"`
+	MachineOnCabinet   uint      `json:",omitempty"`
+	IPMIAddr           net.IP    `json:",omitempty"`
+	Hostname           string    `json:",omitempty"`
+	MachineID          string    `json:",omitempty"`
+	ConnectedNIC       string    `json:",omitempty`
+	FleetMetadata      FleetMeta `json:",omitempty"`
+	FleetDisableEngine bool      `json:",omitempty"`
+	KeepDiskData       bool      `json:",omitempty"`
+	LastBoot           time.Time `json:",omitempty"`
+	Profile            string    `json:",omitempty"`
 
 	State hostState
 

--- a/mayuctl/status.go
+++ b/mayuctl/status.go
@@ -46,6 +46,7 @@ func statusRun(cmd *cobra.Command, args []string) {
 	lines = append(lines, fmt.Sprintf(statusScheme, "MachineID:", host.MachineID))
 	lines = append(lines, fmt.Sprintf(statusScheme, "ConnectedNIC:", host.ConnectedNIC))
 	lines = append(lines, fmt.Sprintf(statusScheme, "Profile:", host.Profile))
+	lines = append(lines, fmt.Sprintf(statusScheme, "DisableEngine:", strconv.FormatBool(host.FleetDisableEngine)))
 	lines = append(lines, fmt.Sprintf(statusScheme, "State:", hostmgr.HostStateMap()[host.State]))
 	lines = append(lines, fmt.Sprintf(statusScheme, "Metadata:", metadata))
 	lines = append(lines, fmt.Sprintf(statusScheme, "CoreOS:", host.CoreOSVersion))

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -36,9 +36,10 @@ type configuration struct {
 }
 
 type profile struct {
-	Quantity int
-	Name     string
-	Tags     []string
+	Quantity      int
+	Name          string
+	Tags          []string
+	DisableEngine bool
 }
 
 type network struct {

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -39,7 +39,7 @@ type profile struct {
 	Quantity      int
 	Name          string
 	Tags          []string
-	DisableEngine bool
+	DisableEngine bool `yaml:"disable_engine"`
 }
 
 type network struct {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -95,6 +95,7 @@ func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {
 		if host.Profile == "" {
 			host.Profile = mgr.getNextProfile()
 			if host.Profile != "" {
+				host.FleetDisableEngine = mgr.profileDisableEngine(host.Profile)
 				host.FleetMetadata = mgr.profileMetadata(host.Profile)
 			} else {
 				host.FleetMetadata = mgr.profileMetadata("default")
@@ -106,6 +107,15 @@ func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {
 		}
 	}
 	return host
+}
+
+func (mgr *pxeManagerT) profileDisableEngine(profileName string) bool {
+	for _, v := range mgr.config.Profiles {
+		if v.Name == profileName {
+			return v.DisableEngine
+		}
+	}
+	return false
 }
 
 func (mgr *pxeManagerT) profileMetadata(profileName string) []string {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -23,6 +23,8 @@ const (
 	vmlinuzFile      = "coreos_production_pxe.vmlinuz"
 	initrdFile       = "coreos_production_pxe_image.cpio.gz"
 	installImageFile = "coreos_production_image.bin.bz2"
+
+	defaultProfileName = "default"
 )
 
 func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +100,8 @@ func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {
 				host.FleetDisableEngine = mgr.profileDisableEngine(host.Profile)
 				host.FleetMetadata = mgr.profileMetadata(host.Profile)
 			} else {
-				host.FleetMetadata = mgr.profileMetadata("default")
+				host.FleetMetadata = mgr.profileMetadata(defaultProfileName)
+				host.FleetDisableEngine = mgr.profileDisableEngine(defaultProfileName)
 			}
 			err = host.Commit("updated host profile and metadata")
 			if err != nil {

--- a/templates/examples/bonding.yaml
+++ b/templates/examples/bonding.yaml
@@ -110,14 +110,13 @@ write_files:
   content: |
     #!/bin/bash
     for i in /sys/class/net/enp* ; do ip link set  $(basename $i) down ; done ; sleep 1 ; systemctl restart systemd-networkd ; sleep 5
-{{if .Host.FleetMetadata}}
 - path: /etc/systemd/system/fleet.service.d/30-giantswarm.conf
   permissions: 0644
   owner: root
   content: |
     [Service]
-    Environment="FLEET_METADATA={{.Host.FleetMetadata}}"
-{{end}}
+    {{if .Host.FleetMetadata}}Environment="FLEET_METADATA={{.Host.FleetMetadata}}"{{end}}
+    {{if .Host.FleetDisableEngine}}Environment="FLEET_DISABLE_ENGINE={{.Host.FleetDisableEngine}}"{{end}}
 {{if eq .ClusterNetwork.NetworkModel "bond"}}
 - path: /etc/modprobe.d/bonding.conf
   permissions: 0644

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -84,7 +84,7 @@ write_files:
   content: |
     [Service]
     {{if .Host.FleetMetadata}}Environment="FLEET_METADATA={{.Host.FleetMetadata}}"{{end}}
-    {{if .Host.FleetDisableEngine}}Environment="FLEET_DISABLE_ENGINE={{.Host.FleetDisableEngine}}"{{end}}
+    Environment="FLEET_DISABLE_ENGINE={{.Host.FleetDisableEngine}}"
 - path: /etc/hosts
   permissions: 0644
   owner: root

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -78,14 +78,13 @@ coreos:
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     listen-peer-urls: http://{{.Host.InternalAddr}}:2380,http://{{.Host.InternalAddr}}:7001
 write_files:
-{{if .Host.FleetMetadata}}
 - path: /etc/systemd/system/fleet.service.d/30-giantswarm.conf
   permissions: 0644
   owner: root
   content: |
     [Service]
-    Environment="FLEET_METADATA={{.Host.FleetMetadata}}"
-{{end}}
+    {{if .Host.FleetMetadata}}Environment="FLEET_METADATA={{.Host.FleetMetadata}}"{{end}}
+    {{if .Host.FleetDisableEngine}}Environment="FLEET_DISABLE_ENGINE={{.Host.FleetDisableEngine}}"{{end}}
 - path: /etc/hosts
   permissions: 0644
   owner: root


### PR DESCRIPTION
We should be able to use the `FLEET_DISABLE_ENGINE` to specify whether our fleet nodes could be elected or not as fleet leaders (or in other words to work as engines). This property should depend on a property specified in the `config.yaml`, `disable_engine`.

State: Testing it in my local cluster