### PR TITLE
Define the coreOS version in the profiles

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -17,8 +17,10 @@ profiles:
     quantity: 3
     tags:
       - "role-core=true"
+    coreos_version: "835.13.0"
   - name: default
     disable_engine: true
+    coreos_version: "835.13.0"
     tags:
       - "role-worker=true"
       - "stack-compute=true"

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -39,7 +39,8 @@ type profile struct {
 	Quantity      int
 	Name          string
 	Tags          []string
-	DisableEngine bool `yaml:"disable_engine"`
+	DisableEngine bool   `yaml:"disable_engine"`
+	CoreOSVersion string `yaml:"coreos_version"`
 }
 
 type network struct {


### PR DESCRIPTION
We can now define the CoreOS version in the profiles `config.yaml`.

ping @teemow 