### PR TITLE
Assign bridge IPs for the hosts

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -8,6 +8,9 @@ network:
   ip_range:
     start: 10.0.3.31
     end: 10.0.3.70
+  bridge_ip_range:
+    start: 12.0.3.31
+    end: 12.0.3.70
   dns: [8.8.8.8, 8.8.4.4]
   router: 10.0.3.251
   network_model: singlenic

--- a/hostmgr/host.go
+++ b/hostmgr/host.go
@@ -22,6 +22,7 @@ type Host struct {
 	Serial             string    `json:",omitempty"`
 	MacAddresses       []string  `json:",omitempty"`
 	InternalAddr       net.IP    `json:",omitempty"`
+	BridgeIP           net.IP    `json:",omitempty"`
 	BondInterfaces     []string  `json:",omitempty"`
 	Cabinet            uint      `json:",omitempty"`
 	MachineOnCabinet   uint      `json:",omitempty"`

--- a/mayuctl/status.go
+++ b/mayuctl/status.go
@@ -37,6 +37,7 @@ func statusRun(cmd *cobra.Command, args []string) {
 	lines := []string{}
 	lines = append(lines, fmt.Sprintf(statusScheme, "Serial:", host.Serial))
 	lines = append(lines, fmt.Sprintf(statusScheme, "IP:", host.InternalAddr))
+	lines = append(lines, fmt.Sprintf(statusScheme, "Bridge IP:", host.BridgeIP))
 	lines = append(lines, fmt.Sprintf(statusScheme, "IPMI:", host.IPMIAddr))
 	lines = append(lines, fmt.Sprintf(statusScheme, "Provider ID:", host.ProviderId))
 	lines = append(lines, fmt.Sprintf(statusScheme, "Macs:", macs))

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -54,6 +54,10 @@ type network struct {
 		Start string
 		End   string
 	} `yaml:"ip_range"`
+	BridgeIPRange struct {
+		Start string
+		End   string
+	} `yaml:"bridge_ip_range"`
 	Router       string
 	DNS          []string
 	PXE          bool

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -100,6 +101,14 @@ func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {
 		if host.InternalAddr == nil {
 			host.InternalAddr = mgr.getNextInternalIP()
 			err = host.Commit("updated host InternalAddr")
+			if err != nil {
+				glog.Fatalln(err)
+			}
+		}
+
+		if mgr.config.Network.NetworkModel == "bridge" || mgr.config.Network.NetworkModel == "bond_bridge" {
+			host.BridgeIP = mgr.getNextBridgeIP()
+			err = host.Commit("updated host BridgeIP")
 			if err != nil {
 				glog.Fatalln(err)
 			}

--- a/template_snippets/ignition/net_bridge.yaml
+++ b/template_snippets/ignition/net_bridge.yaml
@@ -1,7 +1,8 @@
 {{define "net_bridge"}}
+networkd:
+  units:
   - name: 00-{{.Host.ConnectedNIC}}.network
-    runtime: false
-    content: |
+    contents: |
       [Match]
       Name={{.Host.ConnectedNIC}}
 
@@ -10,30 +11,23 @@
       Gateway={{.ClusterNetwork.Router}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
-
-  - name: 00-br0.netdev
-    runtime: true
-    content: |
+  - name: 30-br0.netdev
+    contents: |
       [NetDev]
       Name=br0
       Kind=bridge
-
   - name: 30-br0.network
-    runtime: true
-    content: |
+    contents: |
       [Match]
       Name=br0
-
       [Network]
       Address={{.Host.BridgeIP}}/24
       DHCPServer=yes
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       IPMasquerade=yes
-
   - name: 99-nodhcp.network
-    runtime: false
-    content: |
+    contents: |
       [Match]
       Name=*
 

--- a/templates/ignition/gs_install.yaml
+++ b/templates/ignition/gs_install.yaml
@@ -123,6 +123,7 @@ storage:
 
 {{if eq .ClusterNetwork.NetworkModel "bond"}}{{template "net_bond" .}}{{end}}
 {{if eq .ClusterNetwork.NetworkModel "singlenic"}}{{template "net_singlenic" .}}{{end}}
+{{if eq .ClusterNetwork.NetworkModel "bridge"}}{{template "net_bridge" .}}{{end}}
 
 passwd:
   users:

--- a/templates/last_stage_cloudconfig.yaml
+++ b/templates/last_stage_cloudconfig.yaml
@@ -13,6 +13,7 @@ coreos:
 {{if eq .ClusterNetwork.NetworkModel "bond"}}{{template "net_bond" .}}{{end}}
 {{if eq .ClusterNetwork.NetworkModel "singlenic"}}{{template "net_singlenic" .}}{{end}}
 {{if eq .ClusterNetwork.NetworkModel "bridge"}}{{template "net_bridge" .}}{{end}}
+
   - name: systemd-networkd-wait-online.service
     enable: true
     command: start


### PR DESCRIPTION
If you choose a brigde network model, we are able to declare a range of ips to be used and choose a free one for our hosts.

ping @teemow