### PR TITLE
add default coreos version to config.yaml

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,3 +1,7 @@
+# used to install machines and if no coreos 
+# version is given in the profile
+default_coreos_version: 1010.5.0
+
 network:
   pxe: true
   interface: bond0

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -28,11 +28,10 @@ func loadConfig(filePath string) (configuration, error) {
 }
 
 type configuration struct {
-	TemplatesEnv map[string]interface{} `yaml:"templates_env"`
-
-	Profiles []profile
-
-	Network network
+	DefaultCoreOSVersion string `yaml:"default_coreos_version"`
+	Network              network
+	Profiles             []profile
+	TemplatesEnv         map[string]interface{} `yaml:"templates_env"`
 }
 
 type profile struct {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -231,6 +231,7 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 
 func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 	coreOSversion := mgr.hostCoreOSVersion(r)
+	glog.V(3).Infof("sending CoreOS %s image", coreOSversion)
 
 	if strings.HasSuffix(r.URL.Path, "/vmlinuz") {
 		vmlinuz, err := mgr.getKernelImage(coreOSversion)
@@ -616,22 +617,16 @@ func (mgr *pxeManagerT) welcomeHandler(w http.ResponseWriter, r *http.Request) {
 
 func (mgr *pxeManagerT) hostCoreOSVersion(r *http.Request) string {
 	coreOSversion := mgr.config.DefaultCoreOSVersion
-	fmt.Println("default: ", coreOSversion)
 
 	host, exists := mgr.hostFromSerialVar(r)
 	if exists {
-		fmt.Println("host from serial: ", host.CoreOSVersion)
-
 		if version, exist := host.Overrides["CoreOSVersion"]; exist {
-			fmt.Println("send host override: ", version.(string))
 			return version.(string)
 		}
 
 		if host.CoreOSVersion == "" {
-			fmt.Println("send default: ", coreOSversion)
 			return mgr.config.DefaultCoreOSVersion
 		} else {
-			fmt.Println("send host: ", host.CoreOSVersion)
 			return host.CoreOSVersion
 		}
 	}

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -25,8 +25,6 @@ const (
 	installImageFile = "coreos_production_image.bin.bz2"
 
 	defaultProfileName = "default"
-
-	defaultCoreOSVersion = "835.13.0"
 )
 
 func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +141,7 @@ func (mgr *pxeManagerT) profileCoreOSVersion(profileName string) string {
 			return v.CoreOSVersion
 		}
 	}
-	return defaultCoreOSVersion
+	return mgr.config.DefaultCoreOSVersion
 }
 
 func (mgr *pxeManagerT) profileMetadata(profileName string) []string {
@@ -617,19 +615,23 @@ func (mgr *pxeManagerT) welcomeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (mgr *pxeManagerT) hostCoreOSVersion(r *http.Request) string {
-	coreOSversion := defaultCoreOSVersion
+	coreOSversion := mgr.config.DefaultCoreOSVersion
+	fmt.Println("default: ", coreOSversion)
 
 	host, exists := mgr.hostFromSerialVar(r)
 	if exists {
+		fmt.Println("host from serial: ", host.CoreOSVersion)
+
+		if version, exist := host.Overrides["CoreOSVersion"]; exist {
+			fmt.Println("send host override: ", version.(string))
+			return version.(string)
+		}
+
 		if host.CoreOSVersion == "" {
-			if version, exist := host.Overrides["CoreOSVersion"]; exist {
-				return version.(string)
-			}
-			return defaultCoreOSVersion
+			fmt.Println("send default: ", coreOSversion)
+			return mgr.config.DefaultCoreOSVersion
 		} else {
-			if version, exist := host.Overrides["CoreOSVersion"]; exist {
-				return version.(string)
-			}
+			fmt.Println("send host: ", host.CoreOSVersion)
 			return host.CoreOSVersion
 		}
 	}

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -67,6 +67,10 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		glog.Fatalln(err)
 	}
 
+	if conf.DefaultCoreOSVersion == "" {
+		glog.Fatalf("No default_coreos_version specified in %s\n", c.ConfigFile)
+	}
+
 	mgr := &pxeManagerT{
 		noTLS:                c.NoTLS,
 		httpPort:             c.HTTPPort,


### PR DESCRIPTION
the default coreos version has been hardcoded before. this version is used to bootstrap machines (first boot) and needs to be defined.