### PR TITLE
add fetching of qemu images to run coreos in coreos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ bin-dist: all
 	cp -a templates/* bin-dist/templates
 	cp -a template_snippets/* bin-dist/template_snippets
 	cp scripts/fetch-coreos-image bin-dist/fetch-coreos-image
+	cp scripts/fetch-coreos-qemu-image bin-dist/fetch-coreos-qemu-image
 	cp scripts/fetch-yochu-assets bin-dist/fetch-yochu-assets
 	cd bin-dist && rm -f $(PROJECT).*.tar.gz && tar czf $(PROJECT).$(VERSION)-linux-amd64.tar.gz *
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ Here we provide more detailed documentation about Mayu.
 - [iPXE Setup](ipxe.md)
 - [Compiling Mayu](compiling.md)
 - [Security Overview](security.md)
+- [Qemu KVM inside CoreOS](qemu.md)

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -1,0 +1,131 @@
+# Start KVMs inside CoreOS
+
+If you would like to start CoreOS via KVM inside your physical machines then Mayu can also serve the necessary assets for you.
+
+Btw if you are looking for a way to test Mayu with Qemu. We have created [Onsho](https://github.com/giantswarm/onsho) to reproduce our datacenter setup on a laptop.
+
+## Prepare Mayu
+
+Within a release (or after running `make bin-dist`) you will find a script called `./fetch-coreos-qemu-image.sh`. This image will download the PXE image and kernel but extract the `/usr` filesystem and put it in a folder that can be served by Mayu.
+
+Note: You need to install the CoreOS image signing key to be able to verify the downloads. See https://coreos.com/os/docs/latest/verify-images.html
+
+To fetch CoreOS `1010.5.0` you can run:
+```
+./fetch-coreos-qemu-image 1010.5.0
+```
+
+Or if you prefer the alpha channel use:
+```
+./fetch-coreos-qemu-image 1068.0.0 alpha
+```
+
+This will download the image into a folder called `./images/qemu/<coreos-version>`
+
+## Create a container
+
+This is an example how to create a VM inside of CoreOS. To have some tooling available it is easier to start KVM from within a container. So you need a Dockerfile.
+
+```
+FROM fedora:latest
+
+RUN dnf -y update && \
+    dnf install -y net-tools libattr libattr-devel xfsprogs bridge-utils qemu-kvm  qemu-system-x86 qemu-img && \
+    dnf clean all
+
+ADD run.sh /run.sh
+ADD cloudconfig.yaml /usr/code/cloudconfig/openstack/latest/user_data
+
+RUN mkdir -p /usr/code/{rootfs,images}
+
+ENTRYPOINT ["/run.sh"]
+```
+
+The entrypoint creates a rootfs and starts the actual qemu process to start the virtual machine. This assumes that you have a bridge called `br0` on the host.
+
+```
+#!/bin/bash
+
+set -eu
+
+echo "allow br0" > /etc/qemu/bridge.conf
+
+ROOTFS=/usr/code/rootfs/rootfs.img
+KERNEL=/usr/code/images/coreos_production_qemu.vmlinuz
+USRFS=/usr/code/images/coreos_production_qemu_usr_image.squashfs
+MAC_ADDRESS=$(printf '%02X:%02X:%02X:%02X:%02X:%02X\n' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
+
+if [ ! -f $ROOTFS ]; then
+    truncate -s 4G $ROOTFS
+    mkfs.xfs $ROOTFS
+fi
+
+exec /usr/bin/qemu-system-x86_64 \
+    -nographic \
+    -machine accel=kvm -cpu host -smp 4 \
+    -m 1024 \
+    -enable-kvm \
+    \
+    -net bridge,br=$BRIDGE_NETWORK,vlan=0,helper=/usr/libexec/qemu-bridge-helper \
+    -net nic,vlan=0,model=virtio,macaddr=$MAC_ADDRESS \
+    \
+    -fsdev local,id=conf,security_model=none,readonly,path=/usr/code/cloudconfig \
+    -device virtio-9p-pci,fsdev=conf,mount_tag=config-2 \
+    \
+    -drive if=virtio,file=$USRFS,format=raw,serial=usr.readonly \
+    -drive if=virtio,file=$ROOTFS,format=raw,discard=on,serial=rootfs \
+    \
+    -device sga \
+    -serial mon:stdio \
+    \
+    -kernel $KERNEL \
+    -append "console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw mount.usr=/dev/disk/by-id/virtio-usr.readonly mount.usrflags=ro"
+```
+
+Don't forget to add your own cloudconfig.yaml for your VM. Then build the container image: `docker build -t giantswarm/coreos-qemu .`.
+
+## Fetch the image
+
+Now you just have to fetch the assets from Mayu and start the VM on the host itself. Fetching can be done via a cloudconfig unit on the host. So you need to include this snippet in your `./templates/last_stage_cloudconfig.yaml`.
+
+```
+coreos:
+  units:
+  - name: fetch-qemu-images.service
+    command: start
+    enable: true
+    content: |
+      [Unit]
+      Description=Fetch qemu images from Mayu
+      Wants=network-online.target
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      Environment="IMAGE_DIR=/home/core/images"
+      Environment="KERNEL=coreos_production_qemu.vmlinuz"
+      Environment="USRFS=coreos_production_qemu_usr_image.squashfs"
+      ExecStartPre=/bin/mkdir -p ${IMAGE_DIR}
+      ExecStartPre=/usr/bin/wget {{index .TemplatesEnv "mayu_http_endpoint"}}/images/{{.Host.Serial}}/qemu/${KERNEL} -O ${IMAGE_DIR}/${KERNEL}
+      ExecStartPre=/usr/bin/wget {{index .TemplatesEnv "mayu_http_endpoint"}}/images/{{.Host.Serial}}/qemu/${KERNEL}.sha256 -O ${IMAGE_DIR}/${KERNEL}.sha256
+      ExecStartPre=/usr/bin/wget {{index .TemplatesEnv "mayu_http_endpoint"}}/images/{{.Host.Serial}}/qemu/${USRFS} -O ${IMAGE_DIR}/${USRFS}
+      ExecStartPre=/usr/bin/wget {{index .TemplatesEnv "mayu_http_endpoint"}}/images/{{.Host.Serial}}/qemu/${USRFS}.sha256 -O ${IMAGE_DIR}/${USRFS}.sha256
+      ExecStart=/bin/bash -c "cd ${IMAGE_DIR} && sha256sum -c ${USRFS}.sha256 && sha256sum -c ${KERNEL}.sha256"
+
+      [Install]
+      WantedBy=multi-user.target
+```
+
+## Start the VM
+
+Finally you can start the virtual machine by running the container:
+
+```
+mkdir -p /home/core/vms/foo
+docker run -ti
+    --privileged \
+    --net=host \
+    -v $(pwd)/images:/usr/code/images \
+    -v /home/core/vms/foo/:/usr/code/rootfs/ \
+    giantswarm/coreos-qemu
+```

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -235,85 +235,69 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 	coreOSversion := mgr.hostCoreOSVersion(r)
 	glog.V(3).Infof("sending CoreOS %s image", coreOSversion)
 
+	var (
+		img *os.File
+		err error
+	)
+
 	if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s.sha256", qemuImageFile)) {
-		img, err := mgr.getQemuImageSHA(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, img)
-		defer img.Close()
-		io.Copy(w, img)
+		img, err = mgr.qemuImageSHA(coreOSversion)
 	} else if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s", qemuImageFile)) {
-		img, err := mgr.getQemuImage(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, img)
-		defer img.Close()
-		io.Copy(w, img)
+		img, err = mgr.qemuImage(coreOSversion)
+	} else if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s.sha256", qemuKernelFile)) {
+		img, err = mgr.qemuKernelSHA(coreOSversion)
 	} else if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s", qemuKernelFile)) {
-		img, err := mgr.getQemuKernel(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, img)
-		defer img.Close()
-		io.Copy(w, img)
+		img, err = mgr.qemuKernel(coreOSversion)
+
 	} else if strings.HasSuffix(r.URL.Path, "/vmlinuz") {
-		vmlinuz, err := mgr.getKernelImage(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, vmlinuz)
-		defer vmlinuz.Close()
-		io.Copy(w, vmlinuz)
+		img, err = mgr.pxeKernelImage(coreOSversion)
 	} else if strings.HasSuffix(r.URL.Path, "/initrd.cpio.gz") {
-		initrd, err := mgr.getInitRD(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, initrd)
-		defer initrd.Close()
-		io.Copy(w, initrd)
+		img, err = mgr.pxeInitRD(coreOSversion)
 	} else if strings.HasSuffix(r.URL.Path, "/install_image.bin.bz2") {
-		img, err := mgr.getInstallImage(coreOSversion)
-		if err != nil {
-			panic(err)
-		}
-		setContentLength(w, img)
-		defer img.Close()
-		io.Copy(w, img)
+		img, err = mgr.pxeInstallImage(coreOSversion)
 	} else {
 		panic(fmt.Sprintf("no handler provided for invalid URL path '%s'", r.URL.Path))
 	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	setContentLength(w, img)
+	defer img.Close()
+	io.Copy(w, img)
 }
 
 func defaultHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("got request", r.URL)
 }
 
-func (mgr *pxeManagerT) getInstallImage(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) pxeInstallImage(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/"+coreOSversion, installImageFile))
 }
 
-func (mgr *pxeManagerT) getKernelImage(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) pxeKernelImage(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/"+coreOSversion, vmlinuzFile))
 }
 
-func (mgr *pxeManagerT) getInitRD(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) pxeInitRD(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/"+coreOSversion, initrdFile))
 }
 
-func (mgr *pxeManagerT) getQemuImage(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) qemuImage(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, qemuImageFile))
 }
 
-func (mgr *pxeManagerT) getQemuImageSHA(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) qemuImageSHA(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, fmt.Sprintf("%s.sha256", qemuImageFile)))
 }
 
-func (mgr *pxeManagerT) getQemuKernel(coreOSversion string) (*os.File, error) {
+func (mgr *pxeManagerT) qemuKernel(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, qemuKernelFile))
+}
+
+func (mgr *pxeManagerT) qemuKernelSHA(coreOSversion string) (*os.File, error) {
+	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, fmt.Sprintf("%s.sha256", qemuKernelFile)))
 }
 
 func setContentLength(w http.ResponseWriter, f *os.File) error {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -24,7 +24,7 @@ const (
 	initrdFile       = "coreos_production_pxe_image.cpio.gz"
 	installImageFile = "coreos_production_image.bin.bz2"
 	qemuImageFile    = "coreos_production_qemu_usr_image.squashfs"
-	qemuKernelFile   = "coreos_production_pxe.vmlinuz"
+	qemuKernelFile   = "coreos_production_qemu.vmlinuz"
 
 	defaultProfileName = "default"
 )
@@ -235,7 +235,7 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 	coreOSversion := mgr.hostCoreOSVersion(r)
 	glog.V(3).Infof("sending CoreOS %s image", coreOSversion)
 
-	if strings.HasSuffix(r.URL.Path, "/qemu/usr_image.squashfs.sha256") {
+	if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s.sha256", qemuImageFile)) {
 		img, err := mgr.getQemuImageSHA(coreOSversion)
 		if err != nil {
 			panic(err)
@@ -243,7 +243,7 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 		setContentLength(w, img)
 		defer img.Close()
 		io.Copy(w, img)
-	} else if strings.HasSuffix(r.URL.Path, "/qemu/usr_image.squashfs") {
+	} else if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s", qemuImageFile)) {
 		img, err := mgr.getQemuImage(coreOSversion)
 		if err != nil {
 			panic(err)
@@ -251,7 +251,7 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 		setContentLength(w, img)
 		defer img.Close()
 		io.Copy(w, img)
-	} else if strings.HasSuffix(r.URL.Path, "/qemu/vmlinuz") {
+	} else if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/qemu/%s", qemuKernelFile)) {
 		img, err := mgr.getQemuKernel(coreOSversion)
 		if err != nil {
 			panic(err)
@@ -309,7 +309,7 @@ func (mgr *pxeManagerT) getQemuImage(coreOSversion string) (*os.File, error) {
 }
 
 func (mgr *pxeManagerT) getQemuImageSHA(coreOSversion string) (*os.File, error) {
-	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, qemuImageFile, ".sha256"))
+	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, fmt.Sprintf("%s.sha256", qemuImageFile)))
 }
 
 func (mgr *pxeManagerT) getQemuKernel(coreOSversion string) (*os.File, error) {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -23,6 +23,7 @@ const (
 	vmlinuzFile      = "coreos_production_pxe.vmlinuz"
 	initrdFile       = "coreos_production_pxe_image.cpio.gz"
 	installImageFile = "coreos_production_image.bin.bz2"
+	qemuImageFile    = "coreos_production_qemu_image.img.bz2"
 
 	defaultProfileName = "default"
 )
@@ -257,6 +258,14 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 		setContentLength(w, img)
 		defer img.Close()
 		io.Copy(w, img)
+	} else if strings.HasSuffix(r.URL.Path, "/qemu/coreos_production_qemu_image.img.bz2") {
+		img, err := mgr.getQemuImage(coreOSversion)
+		if err != nil {
+			panic(err)
+		}
+		setContentLength(w, img)
+		defer img.Close()
+		io.Copy(w, img)
 	} else {
 		panic(fmt.Sprintf("no handler provided for invalid URL path '%s'", r.URL.Path))
 	}
@@ -276,6 +285,10 @@ func (mgr *pxeManagerT) getKernelImage(coreOSversion string) (*os.File, error) {
 
 func (mgr *pxeManagerT) getInitRD(coreOSversion string) (*os.File, error) {
 	return os.Open(path.Join(mgr.imagesCacheDir+"/"+coreOSversion, initrdFile))
+}
+
+func (mgr *pxeManagerT) getQemuImage(coreOSversion string) (*os.File, error) {
+	return os.Open(path.Join(mgr.imagesCacheDir+"/qemu/"+coreOSversion, installImageFile))
 }
 
 func setContentLength(w http.ResponseWriter, f *os.File) error {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -258,7 +258,7 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 		setContentLength(w, img)
 		defer img.Close()
 		io.Copy(w, img)
-	} else if strings.HasSuffix(r.URL.Path, "/qemu/coreos_production_qemu_image.img.bz2") {
+	} else if strings.HasSuffix(r.URL.Path, "/qemu/image.img.bz2") {
 		img, err := mgr.getQemuImage(coreOSversion)
 		if err != nil {
 			panic(err)

--- a/scripts/fetch-coreos-qemu-image
+++ b/scripts/fetch-coreos-qemu-image
@@ -7,6 +7,7 @@ set -eu
 COREOS_VERSION=$1
 COREOS_CHANNEL=${2:-stable}
 IMAGE_PATH=$(pwd)/images/qemu/${COREOS_VERSION}
+KERNEL=coreos_production_qemu.vmlinuz
 USRFS=coreos_production_qemu_usr_image.squashfs
 
 mkdir -p ${IMAGE_PATH}
@@ -15,10 +16,10 @@ cd ${IMAGE_PATH}
 # remove old images
 rm -f coreos*
 
-wget -O coreos_production_pxe.vmlinuz http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz
-wget -O coreos_production_pxe.vmlinuz.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz.sig
-wget -O coreos_production_pxe_image.cpio.gz http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz
-wget -O coreos_production_pxe_image.cpio.gz.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz.sig
+wget http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz
+wget http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz.sig
+wget http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz
+wget http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz.sig
 echo "$COREOS_VERSION" > coreos-version
 
 gpg --verify coreos_production_pxe.vmlinuz.sig
@@ -27,6 +28,9 @@ gpg --verify coreos_production_pxe_image.cpio.gz.sig
 docker run --rm -v $IMAGE_PATH:/usr/code/images --net=host ubuntu:wily /bin/bash -c "apt-get update -y && apt-get install cpio && \
       zcat /usr/code/images/coreos_production_pxe_image.cpio.gz | cpio -i --quiet --sparse --to-stdout usr.squashfs > /usr/code/images/$USRFS"
 
+cp coreos_production_pxe.vmlinuz $KERNEL
+
+sha256sum $KERNEL > $KERNEL.sha256
 sha256sum $USRFS > $USRFS.sha256
 
 cd -

--- a/scripts/fetch-coreos-qemu-image
+++ b/scripts/fetch-coreos-qemu-image
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+: ${1?"Usage: $0 <coreos-version>"}
+
+COREOS_VERSION=$1
+COREOS_CHANNEL=${2:-stable}
+IMAGE_PATH=./images/qemu/${COREOS_VERSION}
+
+mkdir -p ${IMAGE_PATH}
+
+# remove old images
+rm -f ${IMAGE_PATH}/coreos*
+
+wget -O ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2 http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_qemu_image.img.bz2 && \
+wget -O ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_qemu_image.img.bz2.sig
+echo "$COREOS_VERSION" > ${IMAGE_PATH}/coreos-version
+
+gpg --verify ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2.sig

--- a/scripts/fetch-coreos-qemu-image
+++ b/scripts/fetch-coreos-qemu-image
@@ -26,7 +26,7 @@ gpg --verify coreos_production_pxe.vmlinuz.sig
 gpg --verify coreos_production_pxe_image.cpio.gz.sig
 
 docker run --rm -v $IMAGE_PATH:/usr/code/images --net=host ubuntu:wily /bin/bash -c "apt-get update -y && apt-get install cpio && \
-      zcat /usr/code/images/coreos_production_pxe_image.cpio.gz | cpio -i --quiet --sparse --to-stdout usr.squashfs > /usr/code/images/$USRFS"
+      zcat /usr/code/images/coreos_production_pxe_image.cpio.gz | cpio -i --quiet --sparse usr.squashfs && mv usr.squashfs /usr/code/images/$USRFS"
 
 cp coreos_production_pxe.vmlinuz $KERNEL
 

--- a/scripts/fetch-coreos-qemu-image
+++ b/scripts/fetch-coreos-qemu-image
@@ -6,15 +6,27 @@ set -eu
 
 COREOS_VERSION=$1
 COREOS_CHANNEL=${2:-stable}
-IMAGE_PATH=./images/qemu/${COREOS_VERSION}
+IMAGE_PATH=$(pwd)/images/qemu/${COREOS_VERSION}
+USRFS=coreos_production_qemu_usr_image.squashfs
 
 mkdir -p ${IMAGE_PATH}
+cd ${IMAGE_PATH}
 
 # remove old images
-rm -f ${IMAGE_PATH}/coreos*
+rm -f coreos*
 
-wget -O ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2 http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_qemu_image.img.bz2 && \
-wget -O ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_qemu_image.img.bz2.sig
-echo "$COREOS_VERSION" > ${IMAGE_PATH}/coreos-version
+wget -O coreos_production_pxe.vmlinuz http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz
+wget -O coreos_production_pxe.vmlinuz.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz.sig
+wget -O coreos_production_pxe_image.cpio.gz http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz
+wget -O coreos_production_pxe_image.cpio.gz.sig http://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz.sig
+echo "$COREOS_VERSION" > coreos-version
 
-gpg --verify ${IMAGE_PATH}/coreos_production_qemu_image.img.bz2.sig
+gpg --verify coreos_production_pxe.vmlinuz.sig
+gpg --verify coreos_production_pxe_image.cpio.gz.sig
+
+docker run --rm -v $IMAGE_PATH:/usr/code/images --net=host ubuntu:wily /bin/bash -c "apt-get update -y && apt-get install cpio && \
+      zcat /usr/code/images/coreos_production_pxe_image.cpio.gz | cpio -i --quiet --sparse --to-stdout usr.squashfs > /usr/code/images/$USRFS"
+
+sha256sum $USRFS > $USRFS.sha256
+
+cd -


### PR DESCRIPTION
We are using KVM to start CoreOS in CoreOS. To make such installations self-contained Mayu is now able to provide the QEMU images too.