### PR TITLE
Convert deprecated EtcdDiscoveryURL to new DefaultEtcdClusterToken

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func (g MayuFlags) ValidateHTTPCertificateFileExistance() (bool, error) {
 }
 
 func mainRun(cmd *cobra.Command, args []string) {
-	glog.V(8).Infoln(fmt.Sprintf("starting mayu version %s", projectVersion))
+	glog.V(8).Infof("starting mayu version %s", projectVersion)
 
 	var err error
 

--- a/pxemgr/etcd_discovery_handlers.go
+++ b/pxemgr/etcd_discovery_handlers.go
@@ -67,9 +67,15 @@ func (mgr *pxeManagerT) etcdDiscoveryNewCluster(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	token, err := mgr.cluster.GenerateEtcdDiscoveryToken(mgr.etcdEndpoint, size)
+	token, err := mgr.cluster.GenerateEtcdDiscoveryToken()
 	if err != nil {
 		httpError(w, fmt.Sprintf("Unable to generate token '%v'", err), 400)
+		return
+	}
+
+	err = mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, token, size)
+	if err != nil {
+		httpError(w, fmt.Sprintf("Unable to store token in etcd '%v'", err), 400)
 		return
 	}
 


### PR DESCRIPTION
Gracefully handle existing etcd discovery url in `cluster.json`. 

 * If `--etcd-discovery` and the old `EtcdDiscoveryURL` are the same discovery -> token is stored and `EtcdDiscoveryURL` is removed
 * If the internal etcd discovery is used (which is the default) then the token is stored in etcd and the `EtcdDiscoveryURL` is removed. Note: the machine/member data is not transferred. Also existing machines will still have the old discovery URL in their cloud-config.
 * If `--etcd-discovery` and the old `EtcdDiscoveryURL`do not match startup is refused and needs to be fixed manually.