### PR TITLE
Regression of glog version to fix noisy logging issue

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -60,7 +60,7 @@ imports:
   version: 2752d97bbd91927dd1c43296dbf8700e50e2708c
   repo: https://github.com/gogo/protobuf
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   repo: https://github.com/golang/groupcache

--- a/vendor/github.com/golang/glog/README
+++ b/vendor/github.com/golang/glog/README
@@ -5,7 +5,7 @@ Leveled execution logs for Go.
 
 This is an efficient pure Go implementation of leveled logs in the
 manner of the open source C++ package
-	https://github.com/google/glog
+	http://code.google.com/p/google-glog
 
 By binding methods to booleans it is possible to use the log package
 without paying the expense of evaluating the arguments to the log.

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -676,10 +676,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
-	if !flag.Parsed() {
-		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
-		os.Stderr.Write(data)
-	} else if l.toStderr {
+	if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {


### PR DESCRIPTION
Fix https://github.com/giantswarm/mayu/issues/75

We should think about using another logging solution: log15 or something else


Problem fixed:
```
mayu_1      | E1028 13:25:15.262408       1 dnsmasq.go:75] signal: killed
mayu_1      | I1028 13:25:15.288934       1 dnsmasq.go:57] 
mayu_1      | I1028 13:25:15.289011       1 dnsmasq.go:57] dnsmasq: failed to create listening socket for 10.0.3.251: Cannot assign requested address
etcd_1      | 2016-10-28 13:25:15.122069 I | etcdserver: restarting member bf9071f4639c75cc in cluster 7bdc11851051b492 at commit index 9807
etcd_1      | 2016-10-28 13:25:15.125842 I | raft: bf9071f4639c75cc became follower at term 3
etcd_1      | 2016-10-28 13:25:15.125866 I | raft: newRaft bf9071f4639c75cc [peers: [], term: 3, commit: 9807, applied: 0, lastindex: 9807, lastterm: 3]
mayu_1      | E1028 13:25:15.289402       1 dnsmasq.go:75] exit status 2
```

ping @giantswarm/team-positive 