### PR TITLE
Etcdendpoint https support

### DIFF
--- a/hostmgr/cluster.go
+++ b/hostmgr/cluster.go
@@ -304,12 +304,12 @@ func (c *Cluster) GenerateEtcdDiscoveryToken() (string, error) {
 func (c *Cluster) StoreEtcdDiscoveryToken(etcdEndpoint, etcdCAFile, token string, size int) error {
 	//http transport for etcd connection
 	transport := client.DefaultTransport
+	// read custom root CA file if https and CAfile is configured
 	if strings.HasPrefix(etcdEndpoint, "https") && etcdCAFile != "" {
 		customCA := x509.NewCertPool()
 
 		pemData, err := ioutil.ReadFile(etcdCAFile)
 		if err != nil {
-		    // do error
 			glog.Fatal("Unable to read custom CA file: ", err)
 		}
 		customCA.AppendCertsFromPEM(pemData)
@@ -323,7 +323,7 @@ func (c *Cluster) StoreEtcdDiscoveryToken(etcdEndpoint, etcdCAFile, token string
 			TLSHandshakeTimeout: 10 * time.Second,
 		}
 	}
-	glog.Infoln("etcd ",etcdEndpoint, " etcdCA file: ",etcdCAFile)
+
 	// store in etcd
 	cfg := client.Config{
 		Endpoints: []string{etcdEndpoint},
@@ -331,7 +331,6 @@ func (c *Cluster) StoreEtcdDiscoveryToken(etcdEndpoint, etcdCAFile, token string
 		// set timeout per request to fail fast when the target endpoint is unavailable
 		HeaderTimeoutPerRequest: time.Second,
 	}
-
 	etcdClient, err := client.New(cfg)
 	if err != nil {
 		return err
@@ -342,7 +341,6 @@ func (c *Cluster) StoreEtcdDiscoveryToken(etcdEndpoint, etcdCAFile, token string
 		PrevExist: client.PrevNoExist,
 		Dir:       true,
 	})
-
 	if err != nil {
 		return err
 	}

--- a/hostmgr/cluster.go
+++ b/hostmgr/cluster.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 )
 
 const clusterConfFile = "cluster.json"
@@ -310,7 +311,7 @@ func (c *Cluster) StoreEtcdDiscoveryToken(etcdEndpoint, etcdCAFile, token string
 
 		pemData, err := ioutil.ReadFile(etcdCAFile)
 		if err != nil {
-			glog.Fatal("Unable to read custom CA file: ", err)
+			return errors.New("Unable to read custom CA file: "+err.Error())
 		}
 		customCA.AppendCertsFromPEM(pemData)
 		transport = &http.Transport{

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func init() {
 	pf.IntVar(&globalFlags.etcdQuorumSize, "etcd-quorum-size", DefaultEtcdQuorumSize, "Default quorum of the etcd clusters")
 	pf.StringVar(&globalFlags.etcdDiscoveryUrl, "etcd-discovery", DefaultEtcdDiscoveryUrl, "External etcd discovery base url (eg https://discovery.etcd.io). Note: This should be the base URL of the discovery without a specific token. Mayu itself creates a token for the etcd clusters.")
 	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature (you must also specify protocol).")
-	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred CA certificate")
+	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred root CA certificate")
 
 	globalFlags.filesystem = fs.DefaultFilesystem
 }

--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ const (
 	DefaultUseInternalEtcdDiscovery bool   = true
 	DefaultEtcdQuorumSize           int    = 3
 	DefaultEtcdDiscoveryUrl         string = ""
-	DefaultEtcdEndpoint             string = "127.0.0.1:2379"
+	DefaultEtcdEndpoint             string = "http://127.0.0.1:2379"
+	DefaultEtcdCA			string = ""
 )
 
 type MayuFlags struct {
@@ -73,6 +74,7 @@ type MayuFlags struct {
 	etcdQuorumSize           int
 	etcdDiscoveryUrl         string
 	etcdEndpoint             string
+	etcdCAfile		 string
 
 	filesystem fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
 }
@@ -130,7 +132,8 @@ func init() {
 	pf.BoolVar(&globalFlags.useInternalEtcdDiscovery, "use-internal-etcd-discovery", DefaultUseInternalEtcdDiscovery, "Use the internal etcd discovery")
 	pf.IntVar(&globalFlags.etcdQuorumSize, "etcd-quorum-size", DefaultEtcdQuorumSize, "Default quorum of the etcd clusters")
 	pf.StringVar(&globalFlags.etcdDiscoveryUrl, "etcd-discovery", DefaultEtcdDiscoveryUrl, "External etcd discovery base url (eg https://discovery.etcd.io). Note: This should be the base URL of the discovery without a specific token. Mayu itself creates a token for the etcd clusters.")
-	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature.")
+	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature (you must also specify protocol).")
+	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred CA certificate")
 
 	globalFlags.filesystem = fs.DefaultFilesystem
 }
@@ -225,6 +228,7 @@ func mainRun(cmd *cobra.Command, args []string) {
 		EtcdQuorumSize:           globalFlags.etcdQuorumSize,
 		EtcdDiscoveryUrl:         globalFlags.etcdDiscoveryUrl,
 		EtcdEndpoint:             globalFlags.etcdEndpoint,
+		EtcdCAFile:		  globalFlags.etcdCAfile,
 		DNSmasqExecutable:        globalFlags.dnsmasq,
 		DNSmasqTemplate:          globalFlags.dnsmasqTemplate,
 		TFTPRoot:                 globalFlags.tFTPRoot,

--- a/pxemgr/etcd_discovery_handlers.go
+++ b/pxemgr/etcd_discovery_handlers.go
@@ -73,7 +73,7 @@ func (mgr *pxeManagerT) etcdDiscoveryNewCluster(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	err = mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, token, size)
+	err = mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, mgr.etcdCAFile, token, size)
 	if err != nil {
 		httpError(w, fmt.Sprintf("Unable to store token in etcd '%v'", err), 400)
 		return
@@ -105,6 +105,7 @@ func (mgr *pxeManagerT) etcdDiscoveryProxyRequest(r *http.Request) (*http.Respon
 		return nil, err
 	}
 
+	
 	for i := 0; i <= 10; i++ {
 		u := url.URL{
 			Scheme:   "http",

--- a/pxemgr/etcd_discovery_handlers.go
+++ b/pxemgr/etcd_discovery_handlers.go
@@ -105,7 +105,6 @@ func (mgr *pxeManagerT) etcdDiscoveryProxyRequest(r *http.Request) (*http.Respon
 		return nil, err
 	}
 
-	
 	for i := 0; i <= 10; i++ {
 		u := url.URL{
 			Scheme:   "http",

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -21,6 +21,7 @@ type PXEManagerConfiguration struct {
 	EtcdQuorumSize           int
 	EtcdDiscoveryUrl         string
 	EtcdEndpoint             string
+	EtcdCAFile		 string
 	DNSmasqExecutable        string
 	DNSmasqTemplate          string
 	TFTPRoot                 string
@@ -58,6 +59,7 @@ type pxeManagerT struct {
 	defaultEtcdQuorumSize    int
 	etcdDiscoveryUrl         string
 	etcdEndpoint             string
+	etcdCAFile		 string
 	version                  string
 
 	config  *configuration
@@ -107,6 +109,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		defaultEtcdQuorumSize:    c.EtcdQuorumSize,
 		etcdDiscoveryUrl:         c.EtcdDiscoveryUrl,
 		etcdEndpoint:             c.EtcdEndpoint,
+		etcdCAFile:		  c.EtcdCAFile,
 		version:                  c.Version,
 
 		config:  &conf,
@@ -130,7 +133,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 
 		if mgr.useInternalEtcdDiscovery {
 			// convert token to internal etcd discovery
-			err := mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, token, mgr.defaultEtcdQuorumSize)
+			err := mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, mgr.etcdCAFile, token, mgr.defaultEtcdQuorumSize)
 			if err != nil {
 				glog.Fatalf("Can't store discovery token in etcd.", baseUrl, mgr.etcdDiscoveryUrl)
 			}
@@ -154,7 +157,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 			if err != nil {
 				glog.Fatalf("Failed to generate etcd cluster token: %s", err)
 			}
-			err := mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, token, mgr.defaultEtcdQuorumSize)
+			err := mgr.cluster.StoreEtcdDiscoveryToken(mgr.etcdEndpoint, mgr.etcdCAFile, token, mgr.defaultEtcdQuorumSize)
 			if err != nil {
 				glog.Fatalf("Failed to store etcd cluster token in etcd: %s", err)
 			}


### PR DESCRIPTION
Mayu only supports connecting to etcd via unsecure `http`
In `vodafone setup` we will be using TLS for `etcd` and since certs will be generated via `vault` we also need `mayu` support for custom root CA when connecting to `etcd`.

Changes:
1. removed hardcoded `http` protocol prefix for etcd endpoint 
2. added support for custom root CA when connecting to `etcd`. (new param `--etcd-cafile`)

ping @giantswarm/team-positive @teemow 