### PR TITLE
updaye-mayu-docker-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.6
 
 RUN apk add --no-cache git ca-certificates dnsmasq 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:latest
 
 RUN apk add --no-cache git ca-certificates dnsmasq 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine
 
 RUN apk add --no-cache git ca-certificates dnsmasq 
 


### PR DESCRIPTION
We built mayu  from `alpine:3.4` and our quay security scan reports 4 high risk vulnerabilities and because we care I wanted to solve this.

Current latest version for alpine is `3.6`

lets switch to `latest` alpine image, so each time we build mayu we have security update

