### PR TITLE
add subnet gateway configuration

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -17,6 +17,7 @@ network:
   router: 10.0.0.1
   network_model: singlenic
   subnet_size: 24
+  subnet_gateway: 10.0.1.1
   vlan_id: -1
 
 profiles:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,11 +71,13 @@ network:
     start: 10.0.3.10
     end: 10.0.3.30
   ip_range:
-    start: 10.0.3.31
-    end: 10.0.3.70
+    start: 10.0.4.31
+    end: 10.0.4.70
   dns: [8.8.8.8]
   ntp: [0.pool.ntp.org, 1.pool.ntp.org]
   router: 10.0.3.251
+  subnet_size: 24
+  subnet_gateway: 10.0.4.251
   network_model: singlenic
 ```
 

--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -63,15 +63,16 @@ type Network struct {
 		Start string
 		End   string
 	} `yaml:"ip_range"`
-	Router       string
-	DNS          []string
-	NTP          []string
-	PXE          bool
-	UEFI         bool
-	SubnetSize   string `yaml:"subnet_size"`
-	VlanId       string `yaml:"vlan_id"`
-	NetworkModel string `yaml:"network_model"`
-	BondMode     string `yaml:"bond_mode"`
+	Router        string
+	DNS           []string
+	NTP           []string
+	PXE           bool
+	UEFI          bool
+	SubnetSize    string `yaml:"subnet_size"`
+	SubnetGateway string `yaml:"subnet_gateway"`
+	VlanId        string `yaml:"vlan_id"`
+	NetworkModel  string `yaml:"network_model"`
+	BondMode      string `yaml:"bond_mode"`
 
 	IgnoredHosts []string
 	StaticHosts  []hostmgr.IPMac

--- a/template_snippets/cloudconfig/net_bond.yaml
+++ b/template_snippets/cloudconfig/net_bond.yaml
@@ -53,7 +53,7 @@
 
       [Network]
       Address={{.Host.InternalAddr}}/{{.ClusterNetwork.SubnetSize}}
-      Gateway={{.ClusterNetwork.Router}}
+      Gateway={{.ClusterNetwork.SubnetGateway}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       {{ range $server := .ClusterNetwork.NTP }}NTP={{ $server }}

--- a/template_snippets/cloudconfig/net_bridge.yaml
+++ b/template_snippets/cloudconfig/net_bridge.yaml
@@ -6,8 +6,8 @@
       Name={{.Host.ConnectedNIC}}
 
       [Network]
-      Address={{.Host.InternalAddr}}/22
-      Gateway={{.ClusterNetwork.Router}}
+      Address={{.Host.InternalAddr}}/{{.ClusterNetwork.SubnetSize}}
+      Gateway={{.ClusterNetwork.SubnetGateway}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       {{ range $server := .ClusterNetwork.NTP }}NTP={{ $server }}

--- a/template_snippets/cloudconfig/net_singlenic.yaml
+++ b/template_snippets/cloudconfig/net_singlenic.yaml
@@ -15,7 +15,7 @@
 
       [Network]
       Address={{.Host.InternalAddr}}/{{.ClusterNetwork.SubnetSize}}
-      Gateway={{.ClusterNetwork.Router}}
+      Gateway={{.ClusterNetwork.SubnetGateway}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       {{ range $server := .ClusterNetwork.NTP }}NTP={{ $server }}

--- a/template_snippets/ignition/net_bond.yaml
+++ b/template_snippets/ignition/net_bond.yaml
@@ -50,7 +50,7 @@ networkd:
 
       [Network]
       Address={{.Host.InternalAddr}}/{{.ClusterNetwork.SubnetSize}}
-      Gateway={{.ClusterNetwork.Router}}
+      Gateway={{.ClusterNetwork.SubnetGateway}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       {{ range $server := .ClusterNetwork.NTP }}NTP={{ $server }}

--- a/template_snippets/ignition/net_singlenic.yaml
+++ b/template_snippets/ignition/net_singlenic.yaml
@@ -14,8 +14,8 @@ networkd:
       Name={{.Host.ConnectedNIC}}
 
       [Network]
-      Address={{.Host.InternalAddr}}/22
-      Gateway={{.ClusterNetwork.Router}}
+      Address={{.Host.InternalAddr}}/{{.ClusterNetwork.SubnetSize}}
+      Gateway={{.ClusterNetwork.SubnetGateway}}
       {{ range $server := .ClusterNetwork.DNS }}DNS={{ $server }}
       {{ end }}
       {{ range $server := .ClusterNetwork.NTP }}NTP={{ $server }}


### PR DESCRIPTION
currently, we were using `{{.ClusterNetwork.Router}}` as gateway, but that is gateway for PXE network and if the network is different then it won't work, so we need another value for gateway.

* added `SubnetGateway` value
* changed templates accordingly (also fixed few outdated templates with SubnetSize)
* docs updated