### PR TITLE
increase verbosity on nonexsiting host file

### DIFF
--- a/hostmgr/cluster.go
+++ b/hostmgr/cluster.go
@@ -430,7 +430,7 @@ func (c *Cluster) cacheHosts() error {
 					lastModTime: host.lastModTime,
 				}
 			} else {
-				glog.V(4).Infof("file '%s' doesn't exist, skipping directory '%s'", hostConfPath, fi.Name())
+				glog.V(14).Infof("file '%s' doesn't exist, skipping directory '%s'", hostConfPath, fi.Name())
 			}
 
 		}


### PR DESCRIPTION
It's kinda annoying when each time `mayu` is doing caching of host inventory  to see completely non-important log messages like:
```
Jul 28 19:51:43 000044c6d0e7cf0e docker[5014]: I0728 19:51:43.497824       1 cluster.go:433] file '/var/lib/mayu/images/conf.json' doesn't exist, skipping directory 'images'
Jul 28 19:51:43 000044c6d0e7cf0e docker[5014]: I0728 19:51:43.497842       1 cluster.go:433] file '/var/lib/mayu/templates/conf.json' doesn't exist, skipping directory 'templates'
Jul 28 19:51:43 000044c6d0e7cf0e docker[5014]: I0728 19:51:43.497848       1 cluster.go:433] file '/var/lib/mayu/yochu/conf.json' doesn't exist, skipping directory 'yochu'
```

I thnik it's not very usefull so moving this log to bigger verbosity level is fine.