### PR TITLE
check template execution errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -279,10 +279,15 @@ func mainRun(cmd *cobra.Command, args []string) {
 			os.Stdout.WriteString(b.String())
 		} else {
 			os.Stdout.WriteString("last stage cloud config:\n")
-			pxeManager.WriteLastStageCC(placeholderHost, os.Stdout)
-
+			if err := pxeManager.WriteLastStageCC(placeholderHost, os.Stdout); err != nil {
+				glog.Error("error found while creating template: ", err)
+				os.Exit(1)
+			}
 			b := bytes.NewBuffer(nil)
-			pxeManager.WriteLastStageCC(placeholderHost, b)
+			if err := pxeManager.WriteLastStageCC(placeholderHost, b); err != nil {
+				glog.Error("error found while creating template: ", err)
+				os.Exit(1)
+			}
 			yamlErr := validateYAML(b.Bytes())
 			if yamlErr != nil {
 				glog.Error("error found while checking generated cloud-config: ", yamlErr)

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -13,12 +13,13 @@ import (
 	"text/template"
 	"time"
 
+	"io/ioutil"
+
 	"github.com/giantswarm/mayu-infopusher/machinedata"
 	"github.com/giantswarm/mayu/hostmgr"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 )
 
 const (
@@ -239,10 +240,18 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 
 	if mgr.useIgnition {
 		glog.V(2).Infoln("generating a final stage ignitionConfig")
-		mgr.WriteIgnitionConfig(*host, w)
+		if err := mgr.WriteIgnitionConfig(*host, w); err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte("generating ignition config failed: " + err.Error()))
+			return
+		}
 	} else {
 		glog.V(2).Infoln("generating a final stage cloudConfig")
-		mgr.WriteLastStageCC(*host, w)
+		if err := mgr.WriteLastStageCC(*host, w); err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte("generating final stage cloudConfig failed: " + err.Error()))
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
If these errors are not checked a `template.Execute` call can fail and still write a valid (but incomplete) yaml without further notice.