### PR TITLE
prevent multiple http headers on template generation error

### DIFF
--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -247,7 +247,6 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 			w.Write([]byte("generating ignition config failed: " + err.Error()))
 			return
 		}
-		buf.WriteTo(w)
 	} else {
 		glog.V(2).Infoln("generating a final stage cloudConfig")
 		if err := mgr.WriteLastStageCC(*host, buf); err != nil {
@@ -256,8 +255,8 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 			w.Write([]byte("generating final stage cloudConfig failed: " + err.Error()))
 			return
 		}
-		buf.WriteTo(w)
 	}
+	buf.WriteTo(w)
 }
 
 func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -238,20 +238,25 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 	}
 	mgr.cluster.Update()
 
+	buf := &bytes.Buffer{}
 	if mgr.useIgnition {
 		glog.V(2).Infoln("generating a final stage ignitionConfig")
-		if err := mgr.WriteIgnitionConfig(*host, w); err != nil {
+		if err := mgr.WriteIgnitionConfig(*host, buf); err != nil {
+			glog.V(2).Infoln("generating ignition config failed: " + err.Error())
 			w.WriteHeader(500)
 			w.Write([]byte("generating ignition config failed: " + err.Error()))
 			return
 		}
+		buf.WriteTo(w)
 	} else {
 		glog.V(2).Infoln("generating a final stage cloudConfig")
-		if err := mgr.WriteLastStageCC(*host, w); err != nil {
+		if err := mgr.WriteLastStageCC(*host, buf); err != nil {
+			glog.V(2).Infoln("generating final stage cloudConfig failed: " + err.Error())
 			w.WriteHeader(500)
 			w.Write([]byte("generating final stage cloudConfig failed: " + err.Error()))
 			return
 		}
+		buf.WriteTo(w)
 	}
 }
 

--- a/pxemgr/pxemanager_test.go
+++ b/pxemgr/pxemanager_test.go
@@ -1,0 +1,156 @@
+package pxemgr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/mayu-infopusher/machinedata"
+	"github.com/giantswarm/mayu/hostmgr"
+)
+
+const (
+	baseConfig = `default_coreos_version: myversion
+network:
+  ip_range:
+    start: 1.1.1.1
+    end: 1.1.1.2
+templates_env:
+  mayu_https_endpoint: https://mayu
+`
+	configOK             = baseConfig + "  storage: mystorage"
+	configErr            = baseConfig
+	lastStageCloudconfig = `before_key: ok
+{{if eq .TemplatesEnv.storage "mystorage"}}storage: mystorage{{end}}
+after_key: ok
+`
+)
+
+var (
+	dir      string
+	fakeEtcd *httptest.Server
+	pxeCfg   PXEManagerConfiguration
+	req      *http.Request
+	w        *httptest.ResponseRecorder
+	cluster  *hostmgr.Cluster
+)
+
+func setUp(t *testing.T) {
+	var err error
+	dir, err = ioutil.TempDir("", "pxmgr_cloudconfig_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "config_ok.yaml"), []byte(configOK), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "config_err.yaml"), []byte(configErr), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "last_stage_cloudconfig.yaml"), []byte(lastStageCloudconfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cluster, err = hostmgr.NewCluster(dir, true)
+	if err != nil {
+		t.Fatalf("creating cluster: %s", err)
+	}
+
+	fakeEtcd = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "{}")
+	}))
+
+	pxeCfg = PXEManagerConfiguration{
+		UseInternalEtcdDiscovery: true,
+		NoTLS:                true,
+		APIPort:              4080,
+		PXEPort:              4081,
+		BindAddress:          "0.0.0.0",
+		UseIgnition:          false,
+		LastStageCloudconfig: filepath.Join(dir, "last_stage_cloudconfig.yaml"),
+		Version:              "1.0.0",
+		EtcdEndpoint:         fakeEtcd.URL,
+	}
+
+	hostData := machinedata.HostData{
+		Serial: "myserial",
+	}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(hostData)
+	req = httptest.NewRequest("POST", "http://127.0.0.1:4080/final-cloud-config.yaml", b)
+	w = httptest.NewRecorder()
+}
+
+func tearDown() {
+	os.RemoveAll(dir)
+	fakeEtcd.Close()
+}
+
+func TestFinalCloudConfigChecksErrorOk(t *testing.T) {
+	setUp(t)
+	defer tearDown()
+
+	pxeCfg.ConfigFile = filepath.Join(dir, "config_ok.yaml")
+	mgr, err := PXEManager(pxeCfg, cluster)
+	if err != nil {
+		t.Fatalf("unable to create a pxe manager: %s\n", err)
+	}
+	mgr.configGenerator(w, req)
+
+	if status := w.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	actual := w.Body.String()
+	expected := `before_key: ok
+storage: mystorage
+after_key: ok
+`
+	if actual != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			actual, expected)
+	}
+
+	// make sure the template is complete
+	if !strings.Contains(actual, "after_key: ok") {
+		t.Errorf("response body contains incomplete template: %s", actual)
+	}
+}
+
+func TestFinalCloudConfigChecksErrorFail(t *testing.T) {
+	setUp(t)
+	defer tearDown()
+
+	pxeCfg.ConfigFile = filepath.Join(dir, "config_err.yaml")
+	mgr, err := PXEManager(pxeCfg, cluster)
+	if err != nil {
+		t.Fatalf("unable to create a pxe manager: %s\n", err)
+	}
+	mgr.configGenerator(w, req)
+
+	if status := w.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
+
+	actual := w.Body.String()
+	expected := `generating final stage cloudConfig failed: template: last_stage_cloudconfig.yaml:2:5: executing "last_stage_cloudconfig.yaml" at <eq .TemplatesEnv.sto...>: error calling eq: invalid type for comparison`
+	if actual != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			actual, expected)
+	}
+
+	// make sure we don't get partial templates
+	if strings.Contains(actual, "before_key: ok") {
+		t.Errorf("response body contains partial template: %s", actual)
+	}
+}

--- a/pxemgr/pxemanager_test.go
+++ b/pxemgr/pxemanager_test.go
@@ -33,51 +33,50 @@ after_key: ok
 `
 )
 
-var (
+type helper struct {
 	dir      string
 	fakeEtcd *httptest.Server
 	pxeCfg   PXEManagerConfiguration
 	req      *http.Request
 	w        *httptest.ResponseRecorder
 	cluster  *hostmgr.Cluster
-)
+}
 
-func setUp(t *testing.T) {
+func setUp(t *testing.T) *helper {
+	h := &helper{}
+
 	var err error
-	dir, err = ioutil.TempDir("", "pxmgr_cloudconfig_")
+	h.dir, err = ioutil.TempDir("", "pxmgr_cloudconfig_")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(dir, "config_ok.yaml"), []byte(configOK), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(h.dir, "config_ok.yaml"), []byte(configOK), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "config_err.yaml"), []byte(configErr), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(h.dir, "config_err.yaml"), []byte(configErr), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "last_stage_cloudconfig.yaml"), []byte(lastStageCloudconfig), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(h.dir, "last_stage_cloudconfig.yaml"), []byte(lastStageCloudconfig), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	cluster, err = hostmgr.NewCluster(dir, true)
+	h.cluster, err = hostmgr.NewCluster(h.dir, true)
 	if err != nil {
 		t.Fatalf("creating cluster: %s", err)
 	}
 
-	fakeEtcd = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h.fakeEtcd = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))
 
-	pxeCfg = PXEManagerConfiguration{
+	h.pxeCfg = PXEManagerConfiguration{
 		UseInternalEtcdDiscovery: true,
 		NoTLS:                true,
 		APIPort:              4080,
 		PXEPort:              4081,
-		BindAddress:          "0.0.0.0",
-		UseIgnition:          false,
-		LastStageCloudconfig: filepath.Join(dir, "last_stage_cloudconfig.yaml"),
-		Version:              "1.0.0",
-		EtcdEndpoint:         fakeEtcd.URL,
+		LastStageCloudconfig: filepath.Join(h.dir, "last_stage_cloudconfig.yaml"),
+		EtcdEndpoint:         h.fakeEtcd.URL,
 	}
 
 	hostData := machinedata.HostData{
@@ -85,32 +84,34 @@ func setUp(t *testing.T) {
 	}
 	b := new(bytes.Buffer)
 	json.NewEncoder(b).Encode(hostData)
-	req = httptest.NewRequest("POST", "http://127.0.0.1:4080/final-cloud-config.yaml", b)
-	w = httptest.NewRecorder()
+	h.req = httptest.NewRequest("POST", "http://127.0.0.1:4080/final-cloud-config.yaml", b)
+	h.w = httptest.NewRecorder()
+
+	return h
 }
 
-func tearDown() {
-	os.RemoveAll(dir)
-	fakeEtcd.Close()
+func tearDown(h *helper) {
+	os.RemoveAll(h.dir)
+	h.fakeEtcd.Close()
 }
 
 func TestFinalCloudConfigChecksErrorOk(t *testing.T) {
-	setUp(t)
-	defer tearDown()
+	h := setUp(t)
+	defer tearDown(h)
 
-	pxeCfg.ConfigFile = filepath.Join(dir, "config_ok.yaml")
-	mgr, err := PXEManager(pxeCfg, cluster)
+	h.pxeCfg.ConfigFile = filepath.Join(h.dir, "config_ok.yaml")
+	mgr, err := PXEManager(h.pxeCfg, h.cluster)
 	if err != nil {
 		t.Fatalf("unable to create a pxe manager: %s\n", err)
 	}
-	mgr.configGenerator(w, req)
+	mgr.configGenerator(h.w, h.req)
 
-	if status := w.Code; status != http.StatusOK {
+	if status := h.w.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
 
-	actual := w.Body.String()
+	actual := h.w.Body.String()
 	expected := `before_key: ok
 storage: mystorage
 after_key: ok
@@ -127,24 +128,24 @@ after_key: ok
 }
 
 func TestFinalCloudConfigChecksErrorFail(t *testing.T) {
-	setUp(t)
-	defer tearDown()
+	h := setUp(t)
+	defer tearDown(h)
 
-	pxeCfg.ConfigFile = filepath.Join(dir, "config_err.yaml")
-	mgr, err := PXEManager(pxeCfg, cluster)
+	h.pxeCfg.ConfigFile = filepath.Join(h.dir, "config_err.yaml")
+	mgr, err := PXEManager(h.pxeCfg, h.cluster)
 	if err != nil {
 		t.Fatalf("unable to create a pxe manager: %s\n", err)
 	}
-	mgr.configGenerator(w, req)
+	mgr.configGenerator(h.w, h.req)
 
-	if status := w.Code; status != http.StatusInternalServerError {
+	if status := h.w.Code; status != http.StatusInternalServerError {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusInternalServerError)
 	}
 
-	actual := w.Body.String()
-	expected := `generating final stage cloudConfig failed: template: last_stage_cloudconfig.yaml:2:5: executing "last_stage_cloudconfig.yaml" at <eq .TemplatesEnv.sto...>: error calling eq: invalid type for comparison`
-	if actual != expected {
+	actual := h.w.Body.String()
+	expected := `generating final stage cloudConfig failed: template: last_stage_cloudconfig.yaml`
+	if !strings.Contains(actual, expected) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			actual, expected)
 	}

--- a/pxemgr/pxemanager_test.go
+++ b/pxemgr/pxemanager_test.go
@@ -72,9 +72,11 @@ func setUp(t *testing.T) *helper {
 
 	h.pxeCfg = PXEManagerConfiguration{
 		UseInternalEtcdDiscovery: true,
-		NoTLS:                true,
+		NoTLS: true,
+		// This port is declared only to allow PXEMAnager instantiation (APIPort and
+		// PXEPort must be different), the server is not going to be started and we
+		// are going to test the handler method directly
 		APIPort:              4080,
-		PXEPort:              4081,
 		LastStageCloudconfig: filepath.Join(h.dir, "last_stage_cloudconfig.yaml"),
 		EtcdEndpoint:         h.fakeEtcd.URL,
 	}
@@ -100,10 +102,14 @@ func TestFinalCloudConfigChecksErrorOk(t *testing.T) {
 	defer tearDown(h)
 
 	h.pxeCfg.ConfigFile = filepath.Join(h.dir, "config_ok.yaml")
+
+	// instantiate PXEManager (no need to start it)
 	mgr, err := PXEManager(h.pxeCfg, h.cluster)
 	if err != nil {
 		t.Fatalf("unable to create a pxe manager: %s\n", err)
 	}
+
+	// call handler func and make assertions on the response recorder
 	mgr.configGenerator(h.w, h.req)
 
 	if status := h.w.Code; status != http.StatusOK {
@@ -132,10 +138,14 @@ func TestFinalCloudConfigChecksErrorFail(t *testing.T) {
 	defer tearDown(h)
 
 	h.pxeCfg.ConfigFile = filepath.Join(h.dir, "config_err.yaml")
+
+	// instantiate PXEManager (no need to start it)
 	mgr, err := PXEManager(h.pxeCfg, h.cluster)
 	if err != nil {
 		t.Fatalf("unable to create a pxe manager: %s\n", err)
 	}
+
+	// call handler func and make assertions on the response recorder
 	mgr.configGenerator(h.w, h.req)
 
 	if status := h.w.Code; status != http.StatusInternalServerError {


### PR DESCRIPTION
Closes: #112

Now the logs on template errors will look like:
```
I0821 13:13:02.528079       1 ipxe_handlers.go:252] generating a final stage cloudConfig
I0821 13:13:02.528101       1 cloudconfig.go:38] templates: [./templates/last_stage_cloudconfig.yaml template_snippets/cloudconfig/g8s_master.yaml template_snippets/cloudconfig/g8s_worker.yaml template_snippets/cloudconfig/net_bond.yaml template_snippets/cloudconfig/net_bridge.yaml template_snippets/cloudconfig/net_singlenic.yaml template_snippets/cloudconfig/net_singlevlan.yaml template_snippets/cloudconfig/nfs.yaml template_snippets/cloudconfig/quobyte.yaml template_snippets/cloudconfig/rook.yaml]
I0821 13:13:02.529806       1 ipxe_handlers.go:254] generating final stage cloudConfig failed: template: last_stage_cloudconfig.yaml:246:5: executing "last_stage_cloudconfig.yaml" at <eq .TemplatesEnv.sto...>: error calling eq: invalid type for comparison
I0821 13:13:02.529829       1 glog_wrapper.go:18] 172.16.238.58 - - [21/Aug/2017:13:13:02 +0000] "POST /final-cloud-config.yaml HTTP/1.1" 500 203
```