### PR TITLE
check for WriteTo error

### DIFF
--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -256,7 +256,9 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
-	buf.WriteTo(w)
+	if _, err := buf.WriteTo(w); err != nil {
+		glog.V(2).Infoln("writing response failed: " + err.Error())
+	}
 }
 
 func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -257,7 +257,7 @@ func (mgr *pxeManagerT) configGenerator(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if _, err := buf.WriteTo(w); err != nil {
-		glog.V(2).Infoln("writing response failed: " + err.Error())
+		glog.Fatalln("writing response failed: " + err.Error())
 	}
 }
 


### PR DESCRIPTION
Added missing check for `WriteTo` error, according to https://golang.org/src/bytes/buffer.go?s=7059:7117#L198 there's a case when it can be different from the error returned by `w.Write`, maybe worth checking for all those too.
