### PR TITLE
add coreos.autologin debug option

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -29,6 +29,7 @@ const (
 	DefaultEtcdDiscoveryUrl         string = ""
 	DefaultEtcdEndpoint             string = "http://127.0.0.1:2379"
 	DefaultEtcdCA                   string = ""
+	DefaultCoreosAutologin          bool   = false
 )
 
 type MayuFlags struct {
@@ -60,6 +61,7 @@ type MayuFlags struct {
 	etcdDiscoveryUrl         string
 	etcdEndpoint             string
 	etcdCAfile               string
+	coreosAutologin          bool
 
 	filesystem fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
 }

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func init() {
 	pf.StringVar(&globalFlags.etcdDiscoveryUrl, "etcd-discovery", DefaultEtcdDiscoveryUrl, "External etcd discovery base url (eg https://discovery.etcd.io). Note: This should be the base URL of the discovery without a specific token. Mayu itself creates a token for the etcd clusters.")
 	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature (you must also specify protocol).")
 	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred root CA certificate")
-
+	pf.BoolVar(&globalFlags.coreosAutologin, "coreos-autologin", DefaultCoreosAutologin, "Sets kernel boot param 'coreos.autologin=1'. This is handy for debugging. Do NOT use for production!")
 	globalFlags.filesystem = fs.DefaultFilesystem
 }
 
@@ -145,6 +145,7 @@ func mainRun(cmd *cobra.Command, args []string) {
 		IgnitionConfig:           globalFlags.ignitionConfig,
 		ImagesCacheDir:           globalFlags.imagesCacheDir,
 		FilesDir:                 globalFlags.filesDir,
+		CoreosAutologin:          globalFlags.coreosAutologin,
 		Version:                  projectVersion,
 	}, cluster)
 	if err != nil {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -28,7 +28,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
 	//if mgr.coreosAutologin {
-	extraFlags += "coreos.autologin=1"
+	extraFlags += "coreos.autologin"
 	glog.V(2).Infof("adding coreos.autologin=1 to kernel args becasue coreos-autlogin=%t\n", mgr.coreosAutologin)
 	//}
 

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -29,7 +29,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	extraFlags := ""
 	//if mgr.coreosAutologin {
 	extraFlags += "coreos.autologin=1 "
-	glog.V(2).Infoln("adding coreos.autologin=1 to kernel args")
+	glog.V(2).Infof("adding coreos.autologin=1 to kernel args becasue coreos-autlogin=%t\n", mgr.coreosAutologin)
 	//}
 
 	// for ignition we use only 1phase installation without mayu-infopusher

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -26,9 +26,13 @@ const (
 func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	buffer := bytes.NewBufferString("")
+	extraFlags := ""
+	if mgr.coreosAutologin {
+		extraFlags += "coreos.autologin=1 "
+	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
-	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M\n", mgr.pxeURL(), mgr.ignitionURL())
+	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())
 	// console=ttyS0,115200n8
 	buffer.WriteString("#!ipxe\n")

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -27,10 +27,10 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
-	//if mgr.coreosAutologin {
-	extraFlags += "coreos.autologin"
-	glog.V(2).Infof("adding coreos.autologin=1 to kernel args becasue coreos-autlogin=%t\n", mgr.coreosAutologin)
-	//}
+	if mgr.coreosAutologin {
+		extraFlags += "coreos.autologin"
+		glog.V(2).Infoln("adding coreos.autologin to kernel args")
+	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
 	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
@@ -43,8 +43,6 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	buffer.WriteString("boot\n")
 
 	w.Write(buffer.Bytes())
-
-	glog.V(2).Infof("kernel = %s\n", kernel)
 }
 
 func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -28,7 +28,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
 	//if mgr.coreosAutologin {
-	extraFlags += "coreos.autologin=1 "
+	extraFlags += "coreos.autologin=1"
 	glog.V(2).Infof("adding coreos.autologin=1 to kernel args becasue coreos-autlogin=%t\n", mgr.coreosAutologin)
 	//}
 
@@ -44,6 +44,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 
 	w.Write(buffer.Bytes())
 
+	glog.V(2).Infof("kernel = %s\n", kernel)
 }
 
 func (mgr *pxeManagerT) maybeCreateHost(serial string) *hostmgr.Host {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -29,6 +29,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	extraFlags := ""
 	if mgr.coreosAutologin {
 		extraFlags += "coreos.autologin=1 "
+		glog.V(2).Infoln("adding coreos.autologin=1 to kernel args")
 	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -27,10 +27,10 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
-	if mgr.coreosAutologin {
-		extraFlags += "coreos.autologin=1 "
-		glog.V(2).Infoln("adding coreos.autologin=1 to kernel args")
-	}
+	//if mgr.coreosAutologin {
+	extraFlags += "coreos.autologin=1 "
+	glog.V(2).Infoln("adding coreos.autologin=1 to kernel args")
+	//}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
 	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -41,6 +41,7 @@ type PXEManagerConfiguration struct {
 	ImagesCacheDir           string
 	FilesDir                 string
 	Version                  string
+	CoreosAutologin          bool
 }
 
 type pxeManagerT struct {
@@ -63,6 +64,7 @@ type pxeManagerT struct {
 	etcdCAFile               string
 	version                  string
 	configFile               string
+	coreosAutologin          bool
 
 	config  *Configuration
 	cluster *hostmgr.Cluster
@@ -118,6 +120,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		etcdCAFile:               c.EtcdCAFile,
 		configFile:               c.ConfigFile,
 		version:                  c.Version,
+		coreosAutologin:          c.CoreosAutologin,
 
 		config:  &conf,
 		cluster: cluster,


### PR DESCRIPTION
add coreos.autologin debug option flag to mayu

When  machine doesn't want to properly join cluster it's handy to have the option to enable `coreos.autologin` so that os will boot into logged console and you can check what is wrong


Should be used only for testing, it's not for production as its security risk.