### PR TITLE
vmware serial fix

### DIFF
--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -114,6 +114,8 @@ func (mgr *pxeManagerT) ignitionGenerator(w http.ResponseWriter, r *http.Request
 	uuid := r.URL.Query().Get("uuid")
 	serial := r.URL.Query().Get("serial")
 
+	glog.Warningf("uuid: %s, serial %s, querry: %s\n", uuid,serial, r.URL.RawQuery)
+
 	hostData := &machinedata.HostData{}
 
 	if serial == "" || serial == kvmStaticSerial {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -114,7 +114,7 @@ func (mgr *pxeManagerT) ignitionGenerator(w http.ResponseWriter, r *http.Request
 	uuid := r.URL.Query().Get("uuid")
 	serial := r.URL.Query().Get("serial")
 
-	glog.Warningf("uuid: %s, serial %s, querry: %s\n", uuid,serial, r.URL.RawQuery)
+	glog.Warningf("uuid: %s, serial %s, querry: %s\n", uuid, serial, r.URL.RawQuery)
 
 	hostData := &machinedata.HostData{}
 

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -118,6 +118,9 @@ func (mgr *pxeManagerT) ignitionGenerator(w http.ResponseWriter, r *http.Request
 
 	hostData := &machinedata.HostData{}
 
+	// If there is no reliable serial then use uuid for identification of machine.
+	// Case 1: serial from kvm vm is static and not unique so we need to use uuid.
+	// Case 2: serial sent by ipxe from vmware machines is truncated and not unique so we need to use uuid.
 	if serial == "" || serial == kvmStaticSerial || strings.Contains(serial, vmwareIdentifier) {
 		hostData.Serial = uuid
 	} else {

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -21,6 +21,8 @@ const (
 	defaultProfileName = "default"
 
 	kvmStaticSerial = "0123456789"
+
+	vmwareIdentifier = "VMware"
 )
 
 func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
@@ -114,11 +116,9 @@ func (mgr *pxeManagerT) ignitionGenerator(w http.ResponseWriter, r *http.Request
 	uuid := r.URL.Query().Get("uuid")
 	serial := r.URL.Query().Get("serial")
 
-	glog.Warningf("uuid: %s, serial %s, querry: %s\n", uuid, serial, r.URL.RawQuery)
-
 	hostData := &machinedata.HostData{}
 
-	if serial == "" || serial == kvmStaticSerial {
+	if serial == "" || serial == kvmStaticSerial || strings.Contains(serial, vmwareIdentifier) {
 		hostData.Serial = uuid
 	} else {
 		hostData.Serial = serial


### PR DESCRIPTION
Unfortunately ipxe doesn't properly parse Vmware serial and it its  unusable for our case so we need to switch to uuid for machine identification.