### PR TITLE
Add new parameter bond_interface_match

### DIFF
--- a/pxemgr/config.go
+++ b/pxemgr/config.go
@@ -65,16 +65,17 @@ type Network struct {
 		Start string
 		End   string
 	} `yaml:"ip_range"`
-	Router        string
-	DNS           []string
-	NTP           []string
-	PXE           bool
-	UEFI          bool
-	SubnetSize    string `yaml:"subnet_size"`
-	SubnetGateway string `yaml:"subnet_gateway"`
-	VlanId        string `yaml:"vlan_id"`
-	NetworkModel  string `yaml:"network_model"`
-	BondMode      string `yaml:"bond_mode"`
+	Router             string
+	DNS                []string
+	NTP                []string
+	PXE                bool
+	UEFI               bool
+	SubnetSize         string `yaml:"subnet_size"`
+	SubnetGateway      string `yaml:"subnet_gateway"`
+	VlanId             string `yaml:"vlan_id"`
+	NetworkModel       string `yaml:"network_model"`
+	BondMode           string `yaml:"bond_mode"`
+	BondInterfaceMatch string `yaml:"bond_interface_match"`
 
 	IgnoredHosts []string
 	StaticHosts  []hostmgr.IPMac

--- a/templates/snippets/net_bond.yaml
+++ b/templates/snippets/net_bond.yaml
@@ -4,7 +4,7 @@ networkd:
   - name: 10-bond0-slave.network
     contents: |
       [Match]
-      Name=en*
+      Name={{ or .ClusterNetwork.BondInterfaceMatch "en*" }}
 
       [Network]
       Bond=bond0


### PR DESCRIPTION
Add new parameter `bond_interface_match` to allow including only specified interfaces to bond