### PR TITLE
Use console=ttyS0 in kernel options

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/giantswarm/mayu/fs"
 )
 
@@ -30,6 +31,7 @@ const (
 	DefaultEtcdEndpoint             string = "http://127.0.0.1:2379"
 	DefaultEtcdCA                   string = ""
 	DefaultCoreosAutologin          bool   = false
+	DefaultConsoleTTY               bool   = false
 )
 
 type MayuFlags struct {
@@ -62,6 +64,7 @@ type MayuFlags struct {
 	etcdEndpoint             string
 	etcdCAfile               string
 	coreosAutologin          bool
+	consoleTTY               bool
 
 	filesystem fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
 }

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func init() {
 	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature (you must also specify protocol).")
 	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred root CA certificate")
 	pf.BoolVar(&globalFlags.coreosAutologin, "coreos-autologin", DefaultCoreosAutologin, "Sets kernel boot param 'coreos.autologin=1'. This is handy for debugging. Do NOT use for production!")
+	pf.BoolVar(&globalFlags.consoleTTY, "console-tty", DefaultConsoleTTY, "Sets kernel boot param 'console=ttyS0'. This is handy for debugging.")
 	globalFlags.filesystem = fs.DefaultFilesystem
 }
 

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func mainRun(cmd *cobra.Command, args []string) {
 		ImagesCacheDir:           globalFlags.imagesCacheDir,
 		FilesDir:                 globalFlags.filesDir,
 		CoreosAutologin:          globalFlags.coreosAutologin,
+		ConsoleTTY:               globalFlags.consoleTTY,
 		Version:                  projectVersion,
 
 		Logger: logger,

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -30,12 +30,12 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
 	if mgr.consoleTTY {
-		extraFlags += "console=ttyS0"
+		extraFlags += " console=ttyS0"
 		mgr.logger.Log("level", "info", "message", "adding 'console=ttyS0' to kernel args")
 	}
 
 	if mgr.coreosAutologin {
-		extraFlags += "coreos.autologin"
+		extraFlags += " coreos.autologin"
 		mgr.logger.Log("level", "info", "message", "adding coreos.autologin to kernel args")
 	}
 

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -35,7 +35,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
-	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
+	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} console=ttyS0 systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())
 	// console=ttyS0,115200n8
 	buffer.WriteString("#!ipxe\n")

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -34,8 +34,13 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 		mgr.logger.Log("level", "info", "message", "adding coreos.autologin to kernel args")
 	}
 
+	if mgr.consoleTTY {
+		extraFlags += "console=ttyS0"
+		mgr.logger.Log("level", "info", "message", "adding console=ttyS0 to kernel args")
+	}
+
 	// for ignition we use only 1phase installation without mayu-infopusher
-	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} console=ttyS0 systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
+	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())
 	// console=ttyS0,115200n8
 	buffer.WriteString("#!ipxe\n")

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -29,14 +29,14 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 	buffer := bytes.NewBufferString("")
 	extraFlags := ""
+	if mgr.consoleTTY {
+		extraFlags += "console=ttyS0"
+		mgr.logger.Log("level", "info", "message", "adding 'console=ttyS0' to kernel args")
+	}
+
 	if mgr.coreosAutologin {
 		extraFlags += "coreos.autologin"
 		mgr.logger.Log("level", "info", "message", "adding coreos.autologin to kernel args")
-	}
-
-	if mgr.consoleTTY {
-		extraFlags += "console=ttyS0"
-		mgr.logger.Log("level", "info", "message", "adding console=ttyS0 to kernel args")
 	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -43,6 +43,7 @@ type PXEManagerConfiguration struct {
 	FilesDir                 string
 	Version                  string
 	CoreosAutologin          bool
+	ConsoleTTY               bool
 
 	Logger micrologger.Logger
 }
@@ -68,6 +69,7 @@ type pxeManagerT struct {
 	version                  string
 	configFile               string
 	coreosAutologin          bool
+	consoleTTY               bool
 
 	config  *Configuration
 	cluster *hostmgr.Cluster
@@ -126,6 +128,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		configFile:               c.ConfigFile,
 		version:                  c.Version,
 		coreosAutologin:          c.CoreosAutologin,
+		consoleTTY:               c.ConsoleTTY,
 
 		config:  &conf,
 		cluster: cluster,


### PR DESCRIPTION
I'm struggling with debugging stuff on testing envs every time, having a console here helps a lot