### PR TITLE
enable systemd rescue shell

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -32,6 +32,7 @@ const (
 	DefaultEtcdCA                   string = ""
 	DefaultCoreosAutologin          bool   = false
 	DefaultConsoleTTY               bool   = false
+	DefaultSystemdShell             bool   = false
 )
 
 type MayuFlags struct {
@@ -65,6 +66,7 @@ type MayuFlags struct {
 	etcdCAfile               string
 	coreosAutologin          bool
 	consoleTTY               bool
+	systemdShell             bool
 
 	filesystem fs.FileSystem // internal filesystem abstraction to enable testing of file operations.
 }

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func init() {
 	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred root CA certificate")
 	pf.BoolVar(&globalFlags.coreosAutologin, "coreos-autologin", DefaultCoreosAutologin, "Sets kernel boot param 'coreos.autologin=1'. This is handy for debugging. Do NOT use for production!")
 	pf.BoolVar(&globalFlags.consoleTTY, "console-tty", DefaultConsoleTTY, "Sets kernel boot param 'console=ttyS0'. This is handy for debugging.")
+	pf.BoolVar(&globalFlags.systemdShell, "systemd-shell", DefaultSystemdShell, "Sets kernel boot param 'rd.shell'. This will be activated if the initramfs fails to boot successfully.")
 	globalFlags.filesystem = fs.DefaultFilesystem
 }
 
@@ -150,6 +151,7 @@ func mainRun(cmd *cobra.Command, args []string) {
 		FilesDir:                 globalFlags.filesDir,
 		CoreosAutologin:          globalFlags.coreosAutologin,
 		ConsoleTTY:               globalFlags.consoleTTY,
+		SystemdShell:             globalFlags.systemdShell,
 		Version:                  projectVersion,
 
 		Logger: logger,

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -40,6 +40,11 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 		mgr.logger.Log("level", "info", "message", "adding coreos.autologin to kernel args")
 	}
 
+	if mgr.systemdShell {
+		extraFlags += " rd.shell"
+		mgr.logger.Log("level", "info", "message", "adding rd.shell to kernel args")
+	}
+
 	// for ignition we use only 1phase installation without mayu-infopusher
 	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -44,6 +44,7 @@ type PXEManagerConfiguration struct {
 	Version                  string
 	CoreosAutologin          bool
 	ConsoleTTY               bool
+	SystemdShell             bool
 
 	Logger micrologger.Logger
 }
@@ -70,6 +71,7 @@ type pxeManagerT struct {
 	configFile               string
 	coreosAutologin          bool
 	consoleTTY               bool
+	systemdShell             bool
 
 	config  *Configuration
 	cluster *hostmgr.Cluster
@@ -129,6 +131,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		version:                  c.Version,
 		coreosAutologin:          c.CoreosAutologin,
 		consoleTTY:               c.ConsoleTTY,
+		systemdShell:             c.SystemdShell,
 
 		config:  &conf,
 		cluster: cluster,


### PR DESCRIPTION
If enabled, this option adds `rd.shell` to the boot commandline flags - allows access to a debugging shell if the boot process fails.

I added this after I ran into issues with new servers having no NICs - they wouldn't boot to a usable shell because they couldn't pull their ignition config.