### PR TITLE
Support configurable Flatcar channel

### DIFF
--- a/scripts/fetch-flatcar-image
+++ b/scripts/fetch-flatcar-image
@@ -2,9 +2,10 @@
 
 set -eu
 
-: ${1?"Usage: $0 <flatcar-version> <path-to-store-images>"}
+: ${1?"Usage: $0 <flatcar-version> <flatcar-channel> <path-to-store-images>"}
 
 FLATCAR_VERSION=$1
+FLATCAR_CHANNEL=$2
 DEFAULT_IMAGES_DIR=$(pwd)/images
 IMAGES_DIR=${IMAGES_DIR:-$DEFAULT_IMAGES_DIR}
 KEEP_IMAGES=${KEEP_IMAGES:-"false"}

--- a/scripts/fetch-flatcar-image
+++ b/scripts/fetch-flatcar-image
@@ -18,9 +18,9 @@ fi
 mkdir -p ${IMAGES_DIR}/${FLATCAR_VERSION}
 
 if [ ! -f ${IMAGES_DIR}/${FLATCAR_VERSION}/keep ]; then
-    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2 http://stable.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2 && \
-    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_production_pxe.vmlinuz  http://stable.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_pxe.vmlinuz && \
-    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_pxe_image.cpio.gz  http://stable.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_pxe_image.cpio.gz
+    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2 http://${FLATCAR_CHANNEL}.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2 && \
+    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_production_pxe.vmlinuz  http://${FLATCAR_CHANNEL}.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_pxe.vmlinuz && \
+    wget -O ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar_pxe_image.cpio.gz  http://${FLATCAR_CHANNEL}.release.flatcar-linux.net/amd64-usr/${FLATCAR_VERSION}/flatcar_production_pxe_image.cpio.gz
     echo "$FLATCAR_VERSION" > ${IMAGES_DIR}/${FLATCAR_VERSION}/flatcar-version
 
     mkdir -p ${IMAGES_DIR}/${FLATCAR_VERSION}/etc/systemd/system/ignition-disks.service.d/


### PR DESCRIPTION
This adds a configurable option passed in to have CP nodes running a Flatcar version from a different channel

I'm not sure about the interface of this script. It accept a parameter `<path-to-store-image>` but it is not used anyhow in the script.