### PR TITLE
Add join function to ignition template context

### DIFF
--- a/pxemgr/filemanager.go
+++ b/pxemgr/filemanager.go
@@ -35,6 +35,7 @@ func (mgr *pxeManagerT) RenderFiles(ctx interface{}) (*Files, error) {
 				_ = mgr.logger.Log("level", "error", "message", fmt.Sprintf("Failed to file: %s", path.Join(mgr.filesDir, dir.Name(), file.Name())), "stack", err)
 				return nil, microerror.Mask(err)
 			}
+
 			var data bytes.Buffer
 			err = tmpl.Execute(&data, ctx)
 			if err != nil {

--- a/pxemgr/ignition.go
+++ b/pxemgr/ignition.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -95,9 +96,12 @@ func maybeInitSnippets(snippets string) {
 	}
 }
 
-func join(s ...string) string {
-	// first arg is sep, remaining args are strings to join
-	return strings.Join(s[1:], s[0])
+func join(sep string, i []interface{}) string {
+	var s []string
+	for _, si := range i {
+		s = append(s, si.(string))
+	}
+	return strings.Join(s, sep)
 }
 
 func getTemplate(path, snippets string) (*template.Template, error) {
@@ -105,14 +109,17 @@ func getTemplate(path, snippets string) (*template.Template, error) {
 	templates := []string{path}
 	templates = append(templates, snippetsFiles...)
 
-	tmpl, err := template.ParseFiles(templates...)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
+	name := filepath.Base(path)
+	tmpl := template.New(name)
 	tmpl.Funcs(map[string]interface{}{
 		"join": join,
 	})
+
+	var err error
+	tmpl, err = tmpl.ParseFiles(templates...)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
 	return tmpl, nil
 }


### PR DESCRIPTION
`join` is a `helm` thing I mistakenly assumed existed in go templates. I'm defining the function so go can use it. I also updated the test so we can see the ignition output.

Example output from the test:
```json
{
  "ignition": {
    "config": {},
    "security": {
      "tls": {}
    },
    "timeouts": {},
    "version": "2.2.0"
  },
  "networkd": {},
  "passwd": {},
  "storage": {},
  "systemd": {
    "units": [
      {
        "enabled": false,
        "mask": true,
        "name": "update-engine.service"
      },
      {
        "dropins": [
          {
            "contents": "[Service]\nEnvironment=\"HTTP_PROXY=http://username:password@uri:123\"\nEnvironment=\"HTTPS_PROXY=http://username:password@uri:123\"\nEnvironment=\"NO_PROXY=example.com,other.example.com\"\n",
            "name": "40-docker.conf"
          }
        ],
        "name": "docker.service"
      }
    ]
  }
}
```