### PR TITLE
DO NOT MERGE: Latest Mayu with old Flatcar for VMWare envs

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -30,7 +30,7 @@ const (
 	DefaultEtcdDiscoveryUrl         string = ""
 	DefaultEtcdEndpoint             string = "http://127.0.0.1:2379"
 	DefaultEtcdCA                   string = ""
-	DefaultCoreosAutologin          bool   = false
+	DefaultFlatcarAutologin         bool   = false
 	DefaultConsoleTTY               bool   = false
 	DefaultSystemdShell             bool   = false
 )
@@ -64,7 +64,7 @@ type MayuFlags struct {
 	etcdDiscoveryUrl         string
 	etcdEndpoint             string
 	etcdCAfile               string
-	coreosAutologin          bool
+	flatcarAutologin         bool
 	consoleTTY               bool
 	systemdShell             bool
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func init() {
 	pf.StringVar(&globalFlags.etcdDiscoveryUrl, "etcd-discovery", DefaultEtcdDiscoveryUrl, "External etcd discovery base url (eg https://discovery.etcd.io). Note: This should be the base URL of the discovery without a specific token. Mayu itself creates a token for the etcd clusters.")
 	pf.StringVar(&globalFlags.etcdEndpoint, "etcd-endpoint", DefaultEtcdEndpoint, "The etcd endpoint for the internal discovery feature (you must also specify protocol).")
 	pf.StringVar(&globalFlags.etcdCAfile, "etcd-cafile", DefaultEtcdCA, "The etcd CA file, if etcd is using non-trustred root CA certificate")
-	pf.BoolVar(&globalFlags.coreosAutologin, "coreos-autologin", DefaultCoreosAutologin, "Sets kernel boot param 'coreos.autologin=1'. This is handy for debugging. Do NOT use for production!")
+	pf.BoolVar(&globalFlags.flatcarAutologin, "flatcar-autologin", DefaultFlatcarAutologin, "Sets kernel boot param 'flatcar.autologin'. This is handy for debugging. Do NOT use for production!")
 	pf.BoolVar(&globalFlags.consoleTTY, "console-tty", DefaultConsoleTTY, "Sets kernel boot param 'console=ttyS0'. This is handy for debugging.")
 	pf.BoolVar(&globalFlags.systemdShell, "systemd-shell", DefaultSystemdShell, "Sets kernel boot param 'rd.shell'. This will be activated if the initramfs fails to boot successfully.")
 	globalFlags.filesystem = fs.DefaultFilesystem
@@ -153,7 +153,7 @@ func mainRun(cmd *cobra.Command, args []string) {
 		IgnitionConfig:           globalFlags.ignitionConfig,
 		ImagesCacheDir:           globalFlags.imagesCacheDir,
 		FilesDir:                 globalFlags.filesDir,
-		CoreosAutologin:          globalFlags.coreosAutologin,
+		FlatcarAutologin:         globalFlags.flatcarAutologin,
 		ConsoleTTY:               globalFlags.consoleTTY,
 		SystemdShell:             globalFlags.systemdShell,
 		Version:                  projectVersion,

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -47,7 +47,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
-	kernel := fmt.Sprintf("kernel %s/images/vmlinuz flatcar.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
+	kernel := fmt.Sprintf("kernel %s/images/vmlinuz flatcar.first_boot=1 initrd=initrd.cpio.gz flatcar.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())
 	// console=ttyS0,115200n8
 	buffer.WriteString("#!ipxe\n")

--- a/pxemgr/ipxe_handlers.go
+++ b/pxemgr/ipxe_handlers.go
@@ -36,9 +36,9 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 		_ = mgr.logger.Log("level", "info", "message", "adding 'console=ttyS0' to kernel args")
 	}
 
-	if mgr.coreosAutologin {
-		extraFlags += " coreos.autologin"
-		_ = mgr.logger.Log("level", "info", "message", "adding coreos.autologin to kernel args")
+	if mgr.flatcarAutologin {
+		extraFlags += " flatcar.autologin"
+		_ = mgr.logger.Log("level", "info", "message", "adding flatcar.autologin to kernel args")
 	}
 
 	if mgr.systemdShell {
@@ -47,7 +47,7 @@ func (mgr *pxeManagerT) ipxeBootScript(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// for ignition we use only 1phase installation without mayu-infopusher
-	kernel := fmt.Sprintf("kernel %s/images/vmlinuz coreos.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
+	kernel := fmt.Sprintf("kernel %s/images/vmlinuz flatcar.first_boot=1 initrd=initrd.cpio.gz coreos.config.url=%s?uuid=${uuid}&serial=${serial} systemd.journald.max_level_console=debug verbose log_buf_len=10M "+extraFlags+"\n", mgr.pxeURL(), mgr.ignitionURL())
 	initrd := fmt.Sprintf("initrd %s/images/initrd.cpio.gz\n", mgr.pxeURL())
 	// console=ttyS0,115200n8
 	buffer.WriteString("#!ipxe\n")
@@ -156,13 +156,13 @@ func (mgr *pxeManagerT) imagesHandler(w http.ResponseWriter, r *http.Request) {
 	var img *os.File
 	var err error
 
-	coreOSversion := mgr.config.DefaultFlatcarVersion
-	_ = mgr.logger.Log("level", "info", "message", fmt.Sprintf("sending Container Linux %s image", coreOSversion))
+	flatcarVersion := mgr.config.DefaultFlatcarVersion
+	_ = mgr.logger.Log("level", "info", "message", fmt.Sprintf("sending Container Linux %s image", flatcarVersion))
 
 	if strings.HasSuffix(r.URL.Path, "/vmlinuz") {
-		img, err = mgr.pxeKernelImage(coreOSversion)
+		img, err = mgr.pxeKernelImage(flatcarVersion)
 	} else if strings.HasSuffix(r.URL.Path, "/initrd.cpio.gz") {
-		img, err = mgr.pxeInitRD(coreOSversion)
+		img, err = mgr.pxeInitRD(flatcarVersion)
 	} else {
 		panic(fmt.Sprintf("no handler provided for invalid URL path '%s'", r.URL.Path))
 	}

--- a/pxemgr/pxemanager.go
+++ b/pxemgr/pxemanager.go
@@ -42,7 +42,7 @@ type PXEManagerConfiguration struct {
 	ImagesCacheDir           string
 	FilesDir                 string
 	Version                  string
-	CoreosAutologin          bool
+	FlatcarAutologin         bool
 	ConsoleTTY               bool
 	SystemdShell             bool
 
@@ -69,7 +69,7 @@ type pxeManagerT struct {
 	etcdCAFile               string
 	version                  string
 	configFile               string
-	coreosAutologin          bool
+	flatcarAutologin         bool
 	consoleTTY               bool
 	systemdShell             bool
 
@@ -129,7 +129,7 @@ func PXEManager(c PXEManagerConfiguration, cluster *hostmgr.Cluster) (*pxeManage
 		etcdCAFile:               c.EtcdCAFile,
 		configFile:               c.ConfigFile,
 		version:                  c.Version,
-		coreosAutologin:          c.CoreosAutologin,
+		flatcarAutologin:         c.FlatcarAutologin,
 		consoleTTY:               c.ConsoleTTY,
 		systemdShell:             c.SystemdShell,
 
@@ -220,7 +220,7 @@ func (mgr *pxeManagerT) startIPXEserver() error {
 	// get ignition
 	mgr.pxeRouter.Methods("GET").PathPrefix("/ignition").HandlerFunc(mgr.ignitionGenerator)
 
-	// endpoint for fetching coreos images defined by machine serial number
+	// endpoint for fetching flatcar images defined by machine serial number
 	mgr.pxeRouter.Methods("GET").PathPrefix("/images/{serial}").HandlerFunc(mgr.imagesHandler)
 
 	// serve static files like


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/17855

this gets us the latest mayu release which allows us to use [hive @v1.9.0](https://github.com/giantswarm/hive/releases/tag/v1.9.0) - this means we can run k8s 1.20.7 on older Flatcar.

this is a fork of https://github.com/giantswarm/mayu/tree/autologin-flag-flatcar with the latest changes from master applied (gets us the `join` function etc).